### PR TITLE
[semver:patch] Force HTTP1.1 when downloading via curl

### DIFF
--- a/src/commands/install-ndk.yml
+++ b/src/commands/install-ndk.yml
@@ -23,7 +23,7 @@ steps:
       command: |
         [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo
 
-        $SUDO curl --silent --show-error --location --fail --retry 3 \
+        $SUDO curl --http1.1 --silent --show-error --location --fail --retry 3 \
           --output /tmp/<<parameters.ndk-version>>.zip \
           https://dl.google.com/android/repository/<<parameters.ndk-version>>-linux-x86_64.zip
 


### PR DESCRIPTION
resolves https://github.com/CircleCI-Public/android-orb/issues/7

### Motivation, issues

curl is having HTTP2 framing layer error, most likely due to
https://github.com/curl/curl/issues/3750 and
https://github.com/curl/curl/issues/4267.
Since it is having an error when using HTTP2, we should force HTTP1.1
when downloading.

Another option is to use `wget`, but `wget` is not usually installed by
default in Linux distributions.

### Description

- force http1.1 in curl command