### PR TITLE
[semver:major] Add commands and job for working with the Android emulator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
           avd-name: test1
           run-logcat: true
           memory: 3072
-          restore-gradle-cache-key: v1-multiple
+          restore-gradle-cache-prefix: v1-multiple
           post-emulator-launch-assemble-command: "cd compose-samples/Owl && ./gradlew assembleDebugAndroidTest && cd ../Jetsnack && ./gradlew assembleDebugAndroidTest"
       - android/run-tests:
           pre-steps:
@@ -84,7 +84,7 @@ jobs:
       - android/run-tests:
           working-directory: ./compose-samples/Jetsnack
       - android/save-gradle-cache:
-          cache-key: v1-multiple
+          cache-prefix: v1-multiple
       - android/kill-emulators
       - run: sdkmanager "system-images;android-28;default;x86"
       - android/create-avd:
@@ -120,15 +120,19 @@ jobs:
         - checkout
         - android/start-emulator-and-run-tests:
             pre-emulator-wait-steps:
-                - run:
-                    name: Clone project
-                    command: |
-                        git clone https://github.com/android/compose-samples
-                        cd compose-samples
-                        # pin the revision for consistency
-                        git checkout f1e930dbe6f209dde9ceb5d3419bbf314aabcb58
-            post-emulator-launch-assemble-command: cd compose-samples/Jetchat && ./gradlew assembleDebugAndroidTest
+              - run:
+                  name: Clone project
+                  command: |
+                      git clone https://github.com/android/compose-samples
+                      cd compose-samples
+                      # pin the revision for consistency
+                      git checkout f1e930dbe6f209dde9ceb5d3419bbf314aabcb58
+              - android/restore-build-cache
+              - run: cd compose-samples/Jetchat && ./gradlew assembleDebugAndroidTest
+            post-emulator-launch-assemble-command: ""
             run-tests-working-directory: ./compose-samples/Jetchat
+            post-run-tests-steps:
+              - android/save-build-cache
 
 prod-deploy_requires: &prod-deploy_requires
   [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,16 +70,6 @@ jobs:
           restore-gradle-cache-prefix: v1-multiple
           post-emulator-launch-assemble-command: "cd compose-samples/Owl && ./gradlew assembleDebugAndroidTest && cd ../Jetsnack && ./gradlew assembleDebugAndroidTest"
       - android/run-tests:
-          pre-steps:
-            - run:
-                name: Dummy pre-steps test
-                command: |
-                  echo "Dummy pre-steps"
-          post-steps:
-            - run:
-                name: Dummy post-steps test
-                command: |
-                  echo "Dummy post-steps"
           working-directory: ./compose-samples/Owl
       - android/run-tests:
           working-directory: ./compose-samples/Jetsnack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           run-logcat: true
           memory: 3072
           restore-gradle-cache-key: v1-multiple
-          post-emulator-launch-assemble-command: "cd compose-samples/Owl && ./gradlew assembleDebugAndroidTest && cd ../Crane && ./gradlew assembleDebugAndroidTest"
+          post-emulator-launch-assemble-command: "cd compose-samples/Owl && ./gradlew assembleDebugAndroidTest && cd ../Jetsnack && ./gradlew assembleDebugAndroidTest"
       - android/run-tests:
           pre-steps:
             - run:
@@ -82,7 +82,7 @@ jobs:
                   echo "Dummy post-steps"
           working-directory: ./compose-samples/Owl
       - android/run-tests:
-          working-directory: ./compose-samples/Crane
+          working-directory: ./compose-samples/Jetsnack
       - android/save-gradle-cache:
           cache-key: v1-multiple
       - android/kill-emulators
@@ -96,8 +96,39 @@ jobs:
           # we expect the no-window parameter to be overriden by override-args
           no-window: true
           override-args: "-delay-adb -verbose -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim"
-          wait-for-emulator: false
+          wait-for-emulator: true
+          restore-gradle-cache-post-emulator-launch: false
+          post-emulator-launch-assemble-command: ""
           disable-animations: false
+          pre-emulator-wait-steps:
+            - run:
+                name: Dummy pre-emulator-wait-steps
+                command: |
+                  echo "Test"
+          post-emulator-wait-steps:
+            - run:
+                name: Dummy post-emulator-wait-steps
+                command: |
+                  echo "Test"
+      - android/kill-emulators
+
+  test-start-emulator-and-run-tests:
+      executor:
+        name: android/android-machine
+        resource-class: xlarge
+      steps:
+        - checkout
+        - android/start-emulator-and-run-tests:
+            pre-emulator-wait-steps:
+                - run:
+                    name: Clone project
+                    command: |
+                        git clone https://github.com/android/compose-samples
+                        cd compose-samples
+                        # pin the revision for consistency
+                        git checkout f1e930dbe6f209dde9ceb5d3419bbf314aabcb58
+            post-emulator-launch-assemble-command: cd compose-samples/Jetchat && ./gradlew assembleDebugAndroidTest
+            run-tests-working-directory: ./compose-samples/Jetchat
 
 prod-deploy_requires: &prod-deploy_requires
   [
@@ -125,6 +156,7 @@ prod-deploy_requires: &prod-deploy_requires
     ui-tests-system-images;android-29;default;x86,
     ui-tests-system-images;android-29;google_apis;x86_64,
     test-emulator-commands,
+    test-start-emulator-and-run-tests
   ]
 
 workflows:
@@ -446,6 +478,8 @@ workflows:
 
       - test-emulator-commands:
           system-image: "system-images;android-29;default;x86"
+
+      - test-start-emulator-and-run-tests
 
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: circleci/android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,7 +465,7 @@ workflows:
       - android/run-ui-tests:
           name: "ui-tests-<<matrix.system-image>>"
           checkout: false
-          job-pre-steps:
+          pre-steps:
             - run:
                 name: Setup project
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,59 @@ jobs:
       - android/install-ndk:
           ndk-version: <<parameters.ndk-version>>
           ndk-sha: <<parameters.ndk-sha>>
+  test-emulator-commands:
+    parameters:
+      system-image:
+        type: string
+    executor: android/android-machine
+    steps:
+      - checkout
+      - run:
+          name: Clone project
+          command: |
+            git clone https://github.com/android/compose-samples
+            cd compose-samples
+            # pin the revision for consistency
+            git checkout f1e930dbe6f209dde9ceb5d3419bbf314aabcb58
+      - android/create-avd:
+          avd-name: test1
+          system-image: <<parameters.system-image>>
+          install: true
+      - android/start-emulator:
+          avd-name: test1
+          run-logcat: true
+          memory: 3072
+          restore-gradle-cache-key: v1-multiple
+          post-emulator-launch-assemble-command: "cd compose-samples/Owl && ./gradlew assembleDebugAndroidTest && cd ../Crane && ./gradlew assembleDebugAndroidTest"
+      - android/run-tests:
+          pre-steps:
+            - run:
+                name: Dummy pre-steps test
+                command: |
+                  echo "Dummy pre-steps"
+          post-steps:
+            - run:
+                name: Dummy post-steps test
+                command: |
+                  echo "Dummy post-steps"
+          working-directory: ./compose-samples/Owl
+      - android/run-tests:
+          working-directory: ./compose-samples/Crane
+      - android/save-gradle-cache:
+          cache-key: v1-multiple
+      - android/kill-emulators
+      - run: sdkmanager "system-images;android-28;default;x86"
+      - android/create-avd:
+          avd-name: test2
+          system-image: system-images;android-28;default;x86
+          install: false
+      - android/start-emulator:
+          avd-name: test2
+          # we expect the no-window parameter to be overriden by override-args
+          no-window: true
+          override-args: "-delay-adb -verbose -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim"
+          wait-for-emulator: false
+          disable-animations: false
 
 prod-deploy_requires: &prod-deploy_requires
   [
@@ -68,7 +121,10 @@ prod-deploy_requires: &prod-deploy_requires
     19c-26-master,
     19c-27-master,
     19c-28-master,
-    19c-29-master
+    19c-29-master,
+    ui-tests-system-images;android-29;default;x86,
+    ui-tests-system-images;android-29;google_apis;x86_64,
+    test-emulator-commands,
   ]
 
 workflows:
@@ -369,6 +425,27 @@ workflows:
           tag: api-29
           ndk-version: android-ndk-r19c
           ndk-sha: fd94d0be6017c6acbd193eb95e09cf4b6f61b834
+
+      - android/run-ui-tests:
+          name: "ui-tests-<<matrix.system-image>>"
+          checkout: false
+          job-pre-steps:
+            - run:
+                name: Setup project
+                command: |
+                  git clone https://github.com/android/compose-samples
+                  cd compose-samples
+                  # pin the revision for consistency
+                  git checkout f1e930dbe6f209dde9ceb5d3419bbf314aabcb58
+                  cd ..
+                  cp -r compose-samples/Jetchat/* .
+                  rm -rf compose-samples
+          matrix:
+            parameters:
+              system-image: ["system-images;android-29;default;x86", "system-images;android-29;google_apis;x86_64"]
+
+      - test-emulator-commands:
+          system-image: "system-images;android-29;default;x86"
 
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: circleci/android

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Ping these folks when changes are made to this repository
-* @iynere @felicianotech
+* @CircleCI-Public/cpeng

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 CircleCI Public
+Copyright (c) 2021 CircleCI Public
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# Android Orb [![CircleCI Build Status](https://circleci.com/gh/CircleCI-Public/android-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/CircleCI-Public/android-orb) [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/circleci/android)](https://circleci.com/orbs/registry/orb/circleci/android) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/CircleCI-Public/android-orb/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
+# Android Orb [![CircleCI Build Status](https://circleci.com/gh/CircleCI-Public/android-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/CircleCI-Public/android-orb) [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/circleci/android)](https://circleci.com/developer/orbs/orb/circleci/android) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/CircleCI-Public/android-orb/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
-An orb for working with Android on CircleCI.
+An orb for working with Android on CircleCI. Supports running UI tests
+that use the Android emulator, using the Android machine image which is
+currently in preview status: https://github.com/CircleCI-Public/android-image-preview-docs
 
 ## Usage
 
-For full usage guidelines, see the [orb registry listing](https://circleci.com/orbs/registry/orb/circleci/android).
+For full usage guidelines, see the [orb registry listing](https://circleci.com/developer/orbs/orb/circleci/android).
 
 ## Documentation
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,5 +1,6 @@
 description: |
-  Orb for working with Android projects on CircleCI. Source: https://github.com/circleci-public/android-orb
+  Orb for working with Android projects on CircleCI.
+  Supports running Android emulator UI tests.
 display:
   source_url: https://github.com/circleci-public/android-orb
 version: 2.1

--- a/src/commands/accept-licenses.yml
+++ b/src/commands/accept-licenses.yml
@@ -7,7 +7,7 @@ steps:
       shell: /bin/bash -e
       description: >
         Accepts all Android SDK licenses.
-        This command is typically not necessary to execute, since the CircleCI convenience images
+        This command is typically not necessary to execute, since the CircleCI machine/convenience images
         ship with all licenses accepted.
         This command will add approximately 10 seconds to the build time.
       # Use a custom shell.

--- a/src/commands/create-avd.yml
+++ b/src/commands/create-avd.yml
@@ -1,0 +1,32 @@
+description: |
+  Create an AVD.
+parameters:
+  avd-name:
+    type: string
+    description: |
+      The name of the AVD to create
+  system-image:
+    type: string
+    description: |
+      Name of system image e.g. "system-images;android-29;default;x86"
+  install:
+    type: boolean
+    description: |
+      Whether to first install the system image via sdkmanager
+  additional-args:
+    type: string
+    default: ""
+    description: |
+      Additional args to be passed directly to the avd creation command
+steps:
+  - when:
+      condition: << parameters.install >>
+      steps:
+        - run:
+            name: Install system image "<< parameters.system-image >>"
+            command: |
+              sdkmanager "<< parameters.system-image >>"
+  - run:
+      name: Create avd "<< parameters.avd-name >>"
+      command: |
+        echo "no" | avdmanager --verbose create avd -n "<< parameters.avd-name >>" -k "<< parameters.system-image >>" << parameters.additional-args >>

--- a/src/commands/create-avd.yml
+++ b/src/commands/create-avd.yml
@@ -8,7 +8,8 @@ parameters:
   system-image:
     type: string
     description: |
-      Name of system image e.g. "system-images;android-29;default;x86"
+      Name of system image e.g. "system-images;android-29;default;x86".
+      It should match the name seen in the "sdkmanager --list" output.
   install:
     type: boolean
     description: |

--- a/src/commands/disable-animations.yml
+++ b/src/commands/disable-animations.yml
@@ -1,0 +1,9 @@
+description: |
+  Disables animations. Requires an emulator to be running.
+steps:
+  - run:
+      name: Disable emulator animations
+      command: |
+        adb shell settings put global window_animation_scale 0.0
+        adb shell settings put global transition_animation_scale 0.0
+        adb shell settings put global animator_duration_scale 0.0

--- a/src/commands/install-ndk.yml
+++ b/src/commands/install-ndk.yml
@@ -1,6 +1,8 @@
 description: >
   Extend CircleCI's Android convenience images by installing a version
   of the Android NDK of your choice.
+  This is not intended for the Android machine image, where the sdkmanager
+  should be used instead.
 
 parameters:
   ndk-version:

--- a/src/commands/kill-emulators.yml
+++ b/src/commands/kill-emulators.yml
@@ -1,0 +1,7 @@
+description: |
+  Terminates any running emulator processes
+steps:
+  - run:
+      name: Kill any running emulators
+      command: |
+        adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill; done

--- a/src/commands/restore-build-cache.yml
+++ b/src/commands/restore-build-cache.yml
@@ -1,6 +1,12 @@
 description: >
   Restore the build cache. See `save_build_cache` for more information.
 
+parameters:
+  cache-prefix:
+    description: Used to form part of the cache key
+    type: string
+    default: v1
+
 steps:
   - restore_cache:
-      key: android-orb-v1-
+      key: android-orb-<<parameters.cache-prefix>>-

--- a/src/commands/restore-gradle-cache.yml
+++ b/src/commands/restore-gradle-cache.yml
@@ -1,7 +1,7 @@
 description: |
   Restore gradle cache
 parameters:
-  cache-key:
+  cache-prefix:
     description: Used to form part of the cache key
     type: string
     default: v1
@@ -12,4 +12,4 @@ steps:
         shasum | awk '{print $1}' > /tmp/gradle_cache_seed
       name: Generate Cache Checksum
   - restore_cache:
-      key: gradle-<< parameters.cache-key>>-{{ arch }}-{{ checksum "/tmp/gradle_cache_seed" }}
+      key: gradle-<< parameters.cache-prefix>>-{{ arch }}-{{ checksum "/tmp/gradle_cache_seed" }}

--- a/src/commands/restore-gradle-cache.yml
+++ b/src/commands/restore-gradle-cache.yml
@@ -1,0 +1,15 @@
+description: |
+  Restore gradle cache
+parameters:
+  cache-key:
+    description: Used to form part of the cache key
+    type: string
+    default: v1
+steps:
+  - run:
+      command: |
+        find . -name 'build.gradle' | sort | xargs cat |
+        shasum | awk '{print $1}' > /tmp/gradle_cache_seed
+      name: Generate Cache Checksum
+  - restore_cache:
+      key: gradle-<< parameters.cache-key>>-{{ arch }}-{{ checksum "/tmp/gradle_cache_seed" }}

--- a/src/commands/restore-gradle-cache.yml
+++ b/src/commands/restore-gradle-cache.yml
@@ -5,11 +5,17 @@ parameters:
     description: Used to form part of the cache key
     type: string
     default: v1
+  find-args:
+    description: |
+      Use this to customize how the find command is used to look for relevant
+      file changes.
+    type: string
+    default: ". -name 'build.gradle'"
 steps:
   - run:
+      name: Generate cache checksum
       command: |
-        find . -name 'build.gradle' | sort | xargs cat |
+        find << parameters.find-args >> | sort | xargs cat |
         shasum | awk '{print $1}' > /tmp/gradle_cache_seed
-      name: Generate Cache Checksum
   - restore_cache:
       key: gradle-<< parameters.cache-prefix>>-{{ arch }}-{{ checksum "/tmp/gradle_cache_seed" }}

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -2,9 +2,11 @@ description: |
   Runs tests, with retries supported
 parameters:
   pre-steps:
+    description: Steps to run before the tests
     type: steps
     default: []
   post-steps:
+    description: Steps to run after the tests
     type: steps
     default: []
   test-command:
@@ -16,15 +18,16 @@ parameters:
     type: string
     default: "."
   max-tries:
+    description: Max number of tries. To disable retries, set this to 1.
     type: integer
     default: 2
   retry-interval:
-    type: integer
     description: Duration in seconds to wait before the next try
+    type: integer
     default: 5
   no-output-timeout:
-    type: string
     description: Use this to configure the no_output_timeout value
+    type: string
     default: 10m
 steps:
   - << parameters.pre-steps >>

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -22,6 +22,10 @@ parameters:
     type: integer
     description: Duration in seconds to wait before the next try
     default: 5
+  no-output-timeout:
+    type: string
+    description: Use this to configure the no_output_timeout value
+    default: 10m
 steps:
   - << parameters.pre-steps >>
   - run:
@@ -44,4 +48,5 @@ steps:
             fi
         }
         run_with_retry
+      no_output_timeout: << parameters.no-output-timeout >>
   - << parameters.post-steps >>

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -1,0 +1,47 @@
+description: |
+  Runs tests, with retries supported
+parameters:
+  pre-steps:
+    type: steps
+    default: []
+  post-steps:
+    type: steps
+    default: []
+  test-command:
+    description: Command to run in order to run the tests
+    type: string
+    default: "./gradlew connectedDebugAndroidTest"
+  working-directory:
+    description: Working directory to run the tests in
+    type: string
+    default: "."
+  max-tries:
+    type: integer
+    default: 2
+  retry-interval:
+    type: integer
+    description: Duration in seconds to wait before the next try
+    default: 5
+steps:
+  - << parameters.pre-steps >>
+  - run:
+      name: Run tests with max tries of <<parameters.max-tries>>
+      working_directory: <<parameters.working-directory>>
+      command: |
+        run_with_retry() {
+            MAX_TRIES=<<parameters.max-tries>>
+            n=1
+            until [ $n -gt $MAX_TRIES ]
+            do
+              echo "Starting test attempt $n"
+              <<parameters.test-command>> && break
+              n=$[$n+1]
+              sleep << parameters.retry-interval >>
+            done
+            if [ $n -gt $MAX_TRIES ]; then
+              echo "Max tries reached (<< parameters.max-tries >>)"
+              exit 1
+            fi
+        }
+        run_with_retry
+  - << parameters.post-steps >>

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -1,14 +1,6 @@
 description: |
   Runs tests, with retries supported
 parameters:
-  pre-steps:
-    description: Steps to run before the tests
-    type: steps
-    default: []
-  post-steps:
-    description: Steps to run after the tests
-    type: steps
-    default: []
   test-command:
     description: Command to run in order to run the tests
     type: string
@@ -30,7 +22,6 @@ parameters:
     type: string
     default: 10m
 steps:
-  - << parameters.pre-steps >>
   - run:
       name: Run tests with max tries of <<parameters.max-tries>>
       working_directory: <<parameters.working-directory>>
@@ -52,4 +43,3 @@ steps:
         }
         run_with_retry
       no_output_timeout: << parameters.no-output-timeout >>
-  - << parameters.post-steps >>

--- a/src/commands/save-build-cache.yml
+++ b/src/commands/save-build-cache.yml
@@ -10,9 +10,15 @@ description: >
 
   See https://developer.android.com/studio/build/build-cache
 
+parameters:
+  cache-prefix:
+    description: Used to form part of the cache key
+    type: string
+    default: v1
+
 steps:
   - save_cache:
-      key: android-orb-v1-{{ epoch }}
+      key: android-orb-<<parameters.cache-prefix>>-{{ epoch }}
       paths:
         - ~/.android/build-cache
         - ~/.android/cache

--- a/src/commands/save-gradle-cache.yml
+++ b/src/commands/save-gradle-cache.yml
@@ -1,13 +1,13 @@
 description: |
   Save gradle cache
 parameters:
-  cache-key:
+  cache-prefix:
     description: Used to form part of the cache key
     type: string
     default: v1
 steps:
   - save_cache:
-      key: gradle-<< parameters.cache-key>>-{{ arch }}-{{ checksum "/tmp/gradle_cache_seed" }}
+      key: gradle-<< parameters.cache-prefix>>-{{ arch }}-{{ checksum "/tmp/gradle_cache_seed" }}
       paths:
         - ~/.gradle/caches
         - ~/.gradle/wrapper

--- a/src/commands/save-gradle-cache.yml
+++ b/src/commands/save-gradle-cache.yml
@@ -1,0 +1,13 @@
+description: |
+  Save gradle cache
+parameters:
+  cache-key:
+    description: Used to form part of the cache key
+    type: string
+    default: v1
+steps:
+  - save_cache:
+      key: gradle-<< parameters.cache-key>>-{{ arch }}-{{ checksum "/tmp/gradle_cache_seed" }}
+      paths:
+        - ~/.gradle/caches
+        - ~/.gradle/wrapper

--- a/src/commands/start-emulator-and-run-tests.yml
+++ b/src/commands/start-emulator-and-run-tests.yml
@@ -29,13 +29,13 @@ parameters:
       If set to "", the emulator will be run without the -gpu flag.
   camera-front:
     type: string
-    default: "none"
+    default: ""
     description: |
       The value to use for the "-camera-front" flag.
       If set to "", the emulator will be run without the -camera-front flag.
   camera-back:
     type: string
-    default: "none"
+    default: ""
     description: |
       The value to use for the "-camera-back" flag.
       If set to "", the emulator will be run without the -camera-back flag.
@@ -111,6 +111,12 @@ parameters:
       is set to true.
     type: string
     default: "v1"
+  restore-gradle-cache-find-args:
+    description: |
+      Use this to customize how the find command is used to look for relevant
+      file changes.
+    type: string
+    default: ". -name 'build.gradle'"
   save-gradle-cache:
     description: |
       Whether to write to the gradle cache after the tests have run
@@ -195,6 +201,7 @@ steps:
       post-emulator-wait-steps: << parameters.post-emulator-wait-steps >>
       run-logcat: << parameters.run-logcat >>
       restore-gradle-cache-prefix: << parameters.restore-gradle-cache-prefix >>
+      restore-gradle-cache-find-args: << parameters.restore-gradle-cache-find-args >>
       disable-animations: << parameters.disable-animations >>
   - run-tests:
       pre-steps: << parameters.pre-run-tests-steps >>

--- a/src/commands/start-emulator-and-run-tests.yml
+++ b/src/commands/start-emulator-and-run-tests.yml
@@ -1,5 +1,7 @@
 description: |
-  Run Android UI tests
+  Creates an AVD, starts an emulator and runs tests.
+  This is a wrapper command that wraps the
+  create-avd, start-emulator and run-tests commands.
 parameters:
   avd-name:
     description: |

--- a/src/commands/start-emulator-and-run-tests.yml
+++ b/src/commands/start-emulator-and-run-tests.yml
@@ -1,21 +1,6 @@
 description: |
-  Run Android UI tests. This is a job that wraps the
-  "start-emulator-and-run-tests" command.
+  Run Android UI tests
 parameters:
-  executor:
-    type: executor
-    description: Executor for the job
-    default: android-machine
-  checkout:
-    type: boolean
-    default: true
-    description: Whether to run the checkout step
-  job-pre-steps:
-    type: steps
-    default: []
-  job-post-steps:
-    type: steps
-    default: []
   avd-name:
     type: string
     description: |
@@ -182,18 +167,15 @@ parameters:
     description: |
       Whether to kill the emulators after the tests complete
     default: true
-executor: << parameters.executor >>
+
 steps:
-  - << parameters.job-pre-steps >>
-  - when:
-      condition: << parameters.checkout >>
-      steps:
-        - checkout
-  - start-emulator-and-run-tests:
+  - create-avd:
       avd-name: << parameters.avd-name >>
       system-image: <<parameters.system-image>>
-      install-system-image: << parameters.install-system-image >>
-      additional-avd-args: << parameters.additional-avd-args >>
+      install: << parameters.install-system-image >>
+      additional-args: << parameters.additional-avd-args >>
+  - start-emulator:
+      avd-name: << parameters.avd-name >>
       gpu: << parameters.gpu >>
       camera-front: << parameters.camera-front >>
       camera-back: << parameters.camera-back >>
@@ -204,8 +186,8 @@ steps:
       no-snapshot: << parameters.no-snapshot >>
       delay-adb: << parameters.delay-adb >>
       verbose: << parameters.verbose >>
-      additional-emulator-args: << parameters.additional-emulator-args >>
-      override-emulator-args: << parameters.override-emulator-args >>
+      additional-args: << parameters.additional-emulator-args >>
+      override-args: << parameters.override-emulator-args >>
       wait-for-emulator: << parameters.wait-for-emulator >>
       pre-emulator-wait-steps: << parameters.pre-emulator-wait-steps >>
       post-emulator-launch-assemble-command: << parameters.post-emulator-launch-assemble-command >>
@@ -213,14 +195,22 @@ steps:
       post-emulator-wait-steps: << parameters.post-emulator-wait-steps >>
       run-logcat: << parameters.run-logcat >>
       restore-gradle-cache-key: << parameters.restore-gradle-cache-key >>
-      save-gradle-cache: << parameters.save-gradle-cache >>
       disable-animations: << parameters.disable-animations >>
-      pre-run-tests-steps: << parameters.pre-run-tests-steps >>
-      post-run-tests-steps: << parameters.post-run-tests-steps >>
-      run-tests-working-directory: << parameters.run-tests-working-directory >>
+  - run-tests:
+      pre-steps: << parameters.pre-run-tests-steps >>
+      post-steps: << parameters.post-run-tests-steps >>
+      working-directory: << parameters.run-tests-working-directory >>
       test-command: << parameters.test-command >>
       max-tries: << parameters.max-tries >>
       retry-interval: << parameters.retry-interval >>
       no-output-timeout: << parameters.no-output-timeout >>
-      kill-emulators: << parameters.kill-emulators >>
-  - << parameters.job-post-steps >>
+  - when:
+      condition: << parameters.save-gradle-cache >>
+      steps:
+        - save-gradle-cache:
+            cache-key: << parameters.restore-gradle-cache-key >>
+  - when:
+      condition: << parameters.kill-emulators >>
+      steps:
+        - kill-emulators
+

--- a/src/commands/start-emulator-and-run-tests.yml
+++ b/src/commands/start-emulator-and-run-tests.yml
@@ -2,91 +2,92 @@ description: |
   Run Android UI tests
 parameters:
   avd-name:
-    type: string
     description: |
       The name of the AVD to create
+    type: string
     default: test
   system-image:
-    type: string
     description: |
-      Name of system image e.g. "system-images;android-29;default;x86"
+      Name of system image e.g. "system-images;android-29;default;x86".
+      It should match the name seen in the "sdkmanager --list" output.
+    type: string
     default: system-images;android-29;default;x86
   install-system-image:
-    type: boolean
     description: |
       Whether to first install the system image via sdkmanager
+    type: boolean
     default: true
   additional-avd-args:
-    type: string
-    default: ""
     description: |
       Additional args to be passed directly to the avd creation command
-  gpu:
     type: string
-    default: "swiftshader_indirect"
+    default: ""
+  gpu:
     description: |
       The value to use for the "-gpu" flag.
       If set to "", the emulator will be run without the -gpu flag.
-  camera-front:
     type: string
-    default: ""
+    default: "swiftshader_indirect"
+  camera-front:
     description: |
       The value to use for the "-camera-front" flag.
       If set to "", the emulator will be run without the -camera-front flag.
-  camera-back:
     type: string
     default: ""
+  camera-back:
     description: |
       The value to use for the "-camera-back" flag.
       If set to "", the emulator will be run without the -camera-back flag.
+    type: string
+    default: ""
   memory:
-    type: integer
-    default: -1
     description: |
       The value to use for the "-memory" flag.
       If set to -1, the emulator will be run without the -memory flag.
+    type: integer
+    default: -1
   no-window:
-    type: boolean
-    default: true
     description: |
       Whether to run the emulator with the -no-window flag
-  no-audio:
     type: boolean
     default: true
+  no-audio:
     description: |
       Whether to run the emulator with the -noaudio flag
-  no-boot-anim:
     type: boolean
     default: true
+  no-boot-anim:
     description: |
       Whether to run the emulator with the -no-boot-anim flag
-  no-snapshot:
     type: boolean
     default: true
+  no-snapshot:
     description: |
       Whether to run the emulator with the -no-snapshot flag
-  delay-adb:
     type: boolean
     default: true
+  delay-adb:
     description: |
       Whether to run the emulator with the -delay-adb flag
-  verbose:
     type: boolean
     default: true
+  verbose:
     description: |
       Whether to run the emulator with the -verbose flag
+    type: boolean
+    default: true
   additional-emulator-args:
-    type: string
-    default: ""
     description: |
       Additional args to be passed directly to the emulator command
-  override-emulator-args:
     type: string
     default: ""
+  override-emulator-args:
     description: |
       If this is set to a non-blank value, the emulator command will be
       run with the -avd flag and the value of "override-args" (i.e. none of the defaults
       provided by the orb command will be used)
+    type: string
+    default: ""
   pre-emulator-wait-steps:
     description: |
       Steps to execute while before beginning to wait for the emulator to start up
@@ -128,24 +129,28 @@ parameters:
     type: steps
     default: []
   wait-for-emulator:
+    description: |
+      Whether to wait for the emulator to start up
     type: boolean
     default: true
-    description: |
-      Wait for the emulator to start up
   run-logcat:
+    description: |
+      Whether to run with logcat in the background, after the emulator starts up
     type: boolean
     default: false
-    description: |
-      Run with logcat in the background, after the emulator starts up
   disable-animations:
+    description: |
+      Whether to disable animations that may interfere with tests, after the emulator starts up
     type: boolean
     default: true
-    description: |
-      Disable animations that may interfere with tests, after the emulator starts up
   pre-run-tests-steps:
+    description: |
+      Steps to run before the tests
     type: steps
     default: []
   post-run-tests-steps:
+    description: |
+      Steps to run after the tests
     type: steps
     default: []
   test-command:
@@ -157,21 +162,22 @@ parameters:
     type: string
     default: "."
   max-tries:
+    description: Max number of tries. To disable retries, set this to 1.
     type: integer
     default: 2
   retry-interval:
-    type: integer
     description: Duration in seconds to wait before the next try
+    type: integer
     default: 5
   no-output-timeout:
-    type: string
     description: |
       Use this to configure the no_output_timeout value of the test run
+    type: string
     default: 10m
   kill-emulators:
-    type: boolean
     description: |
       Whether to kill the emulators after the tests complete
+    type: boolean
     default: true
 
 steps:
@@ -198,10 +204,10 @@ steps:
       pre-emulator-wait-steps: << parameters.pre-emulator-wait-steps >>
       post-emulator-launch-assemble-command: << parameters.post-emulator-launch-assemble-command >>
       restore-gradle-cache-post-emulator-launch: << parameters.restore-gradle-cache-post-emulator-launch >>
-      post-emulator-wait-steps: << parameters.post-emulator-wait-steps >>
-      run-logcat: << parameters.run-logcat >>
       restore-gradle-cache-prefix: << parameters.restore-gradle-cache-prefix >>
       restore-gradle-cache-find-args: << parameters.restore-gradle-cache-find-args >>
+      post-emulator-wait-steps: << parameters.post-emulator-wait-steps >>
+      run-logcat: << parameters.run-logcat >>
       disable-animations: << parameters.disable-animations >>
   - run-tests:
       pre-steps: << parameters.pre-run-tests-steps >>
@@ -220,4 +226,3 @@ steps:
       condition: << parameters.kill-emulators >>
       steps:
         - kill-emulators
-

--- a/src/commands/start-emulator-and-run-tests.yml
+++ b/src/commands/start-emulator-and-run-tests.yml
@@ -105,9 +105,9 @@ parameters:
       and before commencing the wait for the emulator to finish starting up.
     type: boolean
     default: true
-  restore-gradle-cache-key:
+  restore-gradle-cache-prefix:
     description: |
-      Cache key used if the "restore-gradle-cache-post-emulator-launch" parameter
+      Cache prefix used if the "restore-gradle-cache-post-emulator-launch" parameter
       is set to true.
     type: string
     default: "v1"
@@ -194,7 +194,7 @@ steps:
       restore-gradle-cache-post-emulator-launch: << parameters.restore-gradle-cache-post-emulator-launch >>
       post-emulator-wait-steps: << parameters.post-emulator-wait-steps >>
       run-logcat: << parameters.run-logcat >>
-      restore-gradle-cache-key: << parameters.restore-gradle-cache-key >>
+      restore-gradle-cache-prefix: << parameters.restore-gradle-cache-prefix >>
       disable-animations: << parameters.disable-animations >>
   - run-tests:
       pre-steps: << parameters.pre-run-tests-steps >>
@@ -208,7 +208,7 @@ steps:
       condition: << parameters.save-gradle-cache >>
       steps:
         - save-gradle-cache:
-            cache-key: << parameters.restore-gradle-cache-key >>
+            cache-prefix: << parameters.restore-gradle-cache-prefix >>
   - when:
       condition: << parameters.kill-emulators >>
       steps:

--- a/src/commands/start-emulator-and-run-tests.yml
+++ b/src/commands/start-emulator-and-run-tests.yml
@@ -211,14 +211,14 @@ steps:
       post-emulator-wait-steps: << parameters.post-emulator-wait-steps >>
       run-logcat: << parameters.run-logcat >>
       disable-animations: << parameters.disable-animations >>
+  - << parameters.pre-run-tests-steps >>
   - run-tests:
-      pre-steps: << parameters.pre-run-tests-steps >>
-      post-steps: << parameters.post-run-tests-steps >>
       working-directory: << parameters.run-tests-working-directory >>
       test-command: << parameters.test-command >>
       max-tries: << parameters.max-tries >>
       retry-interval: << parameters.retry-interval >>
       no-output-timeout: << parameters.no-output-timeout >>
+  - << parameters.post-run-tests-steps >>
   - when:
       condition: << parameters.save-gradle-cache >>
       steps:

--- a/src/commands/start-emulator.yml
+++ b/src/commands/start-emulator.yml
@@ -88,9 +88,9 @@ parameters:
       and before commencing the wait for the emulator to finish starting up.
     type: boolean
     default: true
-  restore-gradle-cache-key:
+  restore-gradle-cache-prefix:
     description: |
-      Cache key used if the "restore-gradle-cache-post-emulator-launch" parameter
+      Cache prefix used if the "restore-gradle-cache-post-emulator-launch" parameter
       is set to true.
     type: string
     default: "v1"
@@ -163,11 +163,11 @@ steps:
           - equal: [ true, << parameters.wait-for-emulator >> ]
       steps:
         - restore-gradle-cache:
-            cache-key: << parameters.restore-gradle-cache-key >>
+            cache-prefix: << parameters.restore-gradle-cache-prefix >>
   - when:
       condition:
         and:
-          - << parameters.post-emulator-launch-assemble-command >> ]
+          - << parameters.post-emulator-launch-assemble-command >>
           - equal: [ true, << parameters.wait-for-emulator >> ]
       steps:
         - run:

--- a/src/commands/start-emulator.yml
+++ b/src/commands/start-emulator.yml
@@ -1,0 +1,199 @@
+description: Starts an emulator as a background process
+parameters:
+  avd-name:
+    type: string
+    description: |
+      The name of the AVD to use for the emulator
+  gpu:
+    type: string
+    default: "swiftshader_indirect"
+    description: |
+      The value to use for the "-gpu" flag.
+      If set to "", the emulator will be run without the -gpu flag.
+  camera-front:
+    type: string
+    default: "none"
+    description: |
+      The value to use for the "-camera-front" flag.
+      If set to "", the emulator will be run without the -camera-front flag.
+  camera-back:
+    type: string
+    default: "none"
+    description: |
+      The value to use for the "-camera-back" flag.
+      If set to "", the emulator will be run without the -camera-back flag.
+  memory:
+    type: integer
+    default: -1
+    description: |
+      The value to use for the "-memory" flag.
+      If set to -1, the emulator will be run without the -memory flag.
+  no-window:
+    type: boolean
+    default: true
+    description: |
+      Whether to run the emulator with the -no-window flag
+  no-audio:
+    type: boolean
+    default: true
+    description: |
+      Whether to run the emulator with the -noaudio flag
+  no-boot-anim:
+    type: boolean
+    default: true
+    description: |
+      Whether to run the emulator with the -no-boot-anim flag
+  no-snapshot:
+    type: boolean
+    default: true
+    description: |
+      Whether to run the emulator with the -no-snapshot flag
+  delay-adb:
+    type: boolean
+    default: true
+    description: |
+      Whether to run the emulator with the -delay-adb flag
+  verbose:
+    type: boolean
+    default: true
+    description: |
+      Whether to run the emulator with the -verbose flag
+  additional-args:
+    type: string
+    default: ""
+    description: |
+      Additional args to be passed directly to the emulator command
+  override-args:
+    type: string
+    default: ""
+    description: |
+      If this is set to a non-blank value, the emulator command will be
+      run with the -avd flag and the value of "override-args" (i.e. none of the defaults
+      provided by the orb command will be used)
+  pre-emulator-wait-steps:
+    description: |
+      Steps to execute while before beginning to wait for the emulator to start up
+    type: steps
+    default: []
+  post-emulator-launch-assemble-command:
+    description: |
+      If this is set to a non-blank value, the configured command will be run
+      after the emulator has been launched, and before commencing the
+      wait for the emulator to finish starting up.
+    type: string
+    default: "./gradlew assembleDebugAndroidTest"
+  restore-gradle-cache-post-emulator-launch:
+    description: |
+      Whether to restore the gradle cache after the emulator has been launched,
+      and before commencing the wait for the emulator to finish starting up.
+    type: boolean
+    default: true
+  restore-gradle-cache-key:
+    description: |
+      Cache key used if the "restore-gradle-cache-post-emulator-launch" parameter
+      is set to true.
+    type: string
+    default: "v1"
+  post-emulator-wait-steps:
+    description: |
+      Steps to execute after waiting for the emulator to start up
+    type: steps
+    default: []
+  wait-for-emulator:
+    type: boolean
+    default: true
+    description: |
+      Wait for the emulator to start up
+  run-logcat:
+    type: boolean
+    default: false
+    description: |
+      Run with logcat in the background, after the emulator starts up
+  disable-animations:
+    type: boolean
+    default: true
+    description: |
+      Disable animations that may interfere with tests, after the emulator starts up
+steps:
+  - run:
+      name: Start emulator
+      command: |
+        if [ -n "<< parameters.override-args >>" ]; then
+          echo "override-args parameter was supplied; orb defaults will be overridden"
+          emulator -avd <<parameters.avd-name>> << parameters.override-args >>
+        else
+          if [ "<< parameters.no-window >>" == "true" ]; then
+            set -- "$@" -no-window
+          fi
+          if [ "<< parameters.no-audio >>" == "true" ]; then
+            set -- "$@" -no-audio
+          fi
+          if [ "<< parameters.no-boot-anim >>" == "true" ]; then
+            set -- "$@" -no-boot-anim
+          fi
+          if [ "<< parameters.verbose >>" == "true" ]; then
+            set -- "$@" -verbose
+          fi
+          if [ "<< parameters.no-snapshot >>" == "true" ]; then
+            set -- "$@" -no-snapshot
+          fi
+          if [ "<< parameters.delay-adb >>" == "true" ]; then
+            set -- "$@" -delay-adb
+          fi
+          if [ "<< parameters.memory >>" != "-1" ]; then
+            set -- "$@" -memory << parameters.memory >>
+          fi
+          if [ -n "<< parameters.gpu >>" ]; then
+            set -- "$@" -gpu "<< parameters.gpu >>"
+          fi
+          if [ -n "<< parameters.camera-front >>" ]; then
+            set -- "$@" -camera-front "<< parameters.camera-front >>"
+          fi
+          if [ -n "<< parameters.camera-back >>" ]; then
+            set -- "$@" -camera-back "<< parameters.camera-back >>"
+          fi
+          echo "Starting emulator with arguments $@ << parameters.additional-args >>"
+          emulator -avd <<parameters.avd-name>> "$@" << parameters.additional-args >>
+        fi
+      background: true
+  - when:
+      condition:
+        and:
+          - << parameters.restore-gradle-cache-post-emulator-launch >> ]
+          - equal: [ true, << parameters.wait-for-emulator >> ]
+      steps:
+        - restore-gradle-cache:
+            cache-key: << parameters.restore-gradle-cache-key >>
+  - when:
+      condition:
+        and:
+          - << parameters.post-emulator-launch-assemble-command >> ]
+          - equal: [ true, << parameters.wait-for-emulator >> ]
+      steps:
+        - run:
+            name: "Assemble app: << parameters.post-emulator-launch-assemble-command >>"
+            command: |
+              # This is meant to do something useful in parallel with the emulator
+              # starting up, like assembling the app, which is required for UI tests
+              << parameters.post-emulator-launch-assemble-command >>
+  - when:
+      condition: << parameters.wait-for-emulator >>
+      steps:
+        - << parameters.pre-emulator-wait-steps >>
+  - when:
+      condition: << parameters.wait-for-emulator >>
+      steps:
+        - wait-for-emulator
+        - when:
+            condition: << parameters.run-logcat >>
+            steps:
+              - run:
+                  name: Logcat
+                  command: |
+                    adb logcat
+                  background: true
+        - when:
+            condition: << parameters.disable-animations >>
+            steps:
+                - disable-animations
+  - << parameters.post-emulator-wait-steps >>

--- a/src/commands/start-emulator.yml
+++ b/src/commands/start-emulator.yml
@@ -94,6 +94,12 @@ parameters:
       is set to true.
     type: string
     default: "v1"
+  restore-gradle-cache-find-args:
+    description: |
+      Use this to customize how the find command is used to look for relevant
+      file changes.
+    type: string
+    default: ". -name 'build.gradle'"
   post-emulator-wait-steps:
     description: |
       Steps to execute after waiting for the emulator to start up
@@ -164,6 +170,7 @@ steps:
       steps:
         - restore-gradle-cache:
             cache-prefix: << parameters.restore-gradle-cache-prefix >>
+            find-args: << parameters.restore-gradle-cache-find-args >>
   - when:
       condition:
         and:

--- a/src/commands/start-emulator.yml
+++ b/src/commands/start-emulator.yml
@@ -1,8 +1,11 @@
-description: Start an emulator as a background process
+description: |
+  Start an emulator as a background process.
+  The AVD used should already be created. (See "create-avd" command for how
+  one could be created)
 parameters:
   avd-name:
     description: |
-      The name of the AVD to use for the emulator
+      The name of the existing AVD to use for the emulator
     type: string
   gpu:
     description: |

--- a/src/commands/start-emulator.yml
+++ b/src/commands/start-emulator.yml
@@ -1,75 +1,75 @@
-description: Starts an emulator as a background process
+description: Start an emulator as a background process
 parameters:
   avd-name:
-    type: string
     description: |
       The name of the AVD to use for the emulator
-  gpu:
     type: string
-    default: "swiftshader_indirect"
+  gpu:
     description: |
       The value to use for the "-gpu" flag.
       If set to "", the emulator will be run without the -gpu flag.
-  camera-front:
     type: string
-    default: "none"
+    default: "swiftshader_indirect"
+  camera-front:
     description: |
       The value to use for the "-camera-front" flag.
       If set to "", the emulator will be run without the -camera-front flag.
-  camera-back:
     type: string
-    default: "none"
+    default: ""
+  camera-back:
     description: |
       The value to use for the "-camera-back" flag.
       If set to "", the emulator will be run without the -camera-back flag.
+    type: string
+    default: ""
   memory:
-    type: integer
-    default: -1
     description: |
       The value to use for the "-memory" flag.
       If set to -1, the emulator will be run without the -memory flag.
+    type: integer
+    default: -1
   no-window:
-    type: boolean
-    default: true
     description: |
       Whether to run the emulator with the -no-window flag
-  no-audio:
     type: boolean
     default: true
+  no-audio:
     description: |
       Whether to run the emulator with the -noaudio flag
-  no-boot-anim:
     type: boolean
     default: true
+  no-boot-anim:
     description: |
       Whether to run the emulator with the -no-boot-anim flag
-  no-snapshot:
     type: boolean
     default: true
+  no-snapshot:
     description: |
       Whether to run the emulator with the -no-snapshot flag
-  delay-adb:
     type: boolean
     default: true
+  delay-adb:
     description: |
       Whether to run the emulator with the -delay-adb flag
-  verbose:
     type: boolean
     default: true
+  verbose:
     description: |
       Whether to run the emulator with the -verbose flag
+    type: boolean
+    default: true
   additional-args:
-    type: string
-    default: ""
     description: |
       Additional args to be passed directly to the emulator command
-  override-args:
     type: string
     default: ""
+  override-args:
     description: |
       If this is set to a non-blank value, the emulator command will be
       run with the -avd flag and the value of "override-args" (i.e. none of the defaults
       provided by the orb command will be used)
+    type: string
+    default: ""
   pre-emulator-wait-steps:
     description: |
       Steps to execute while before beginning to wait for the emulator to start up
@@ -106,20 +106,20 @@ parameters:
     type: steps
     default: []
   wait-for-emulator:
+    description: |
+      Whether to wait for the emulator to start up
     type: boolean
     default: true
-    description: |
-      Wait for the emulator to start up
   run-logcat:
+    description: |
+      Whether to run with logcat in the background, after the emulator starts up
     type: boolean
     default: false
-    description: |
-      Run with logcat in the background, after the emulator starts up
   disable-animations:
+    description: |
+      Whether to disable animations that may interfere with tests, after the emulator starts up
     type: boolean
     default: true
-    description: |
-      Disable animations that may interfere with tests, after the emulator starts up
 steps:
   - run:
       name: Start emulator
@@ -178,7 +178,7 @@ steps:
           - equal: [ true, << parameters.wait-for-emulator >> ]
       steps:
         - run:
-            name: "Assemble app: << parameters.post-emulator-launch-assemble-command >>"
+            name: "Run: << parameters.post-emulator-launch-assemble-command >>"
             command: |
               # This is meant to do something useful in parallel with the emulator
               # starting up, like assembling the app, which is required for UI tests
@@ -203,4 +203,4 @@ steps:
             condition: << parameters.disable-animations >>
             steps:
                 - disable-animations
-  - << parameters.post-emulator-wait-steps >>
+        - << parameters.post-emulator-wait-steps >>

--- a/src/commands/wait-for-emulator.yml
+++ b/src/commands/wait-for-emulator.yml
@@ -1,0 +1,8 @@
+description: |
+  Wait for the emulator to start.
+  Requires the "circle-android" script being present in PATH.
+steps:
+  - run:
+      name: Wait for the emulator to start
+      command: |
+        circle-android wait-for-boot

--- a/src/commands/wait-for-emulator.yml
+++ b/src/commands/wait-for-emulator.yml
@@ -1,6 +1,6 @@
 description: |
   Wait for the emulator to start.
-  Requires the "circle-android" script being present in PATH.
+  Requires the "circle-android" script to be present in PATH.
 steps:
   - run:
       name: Wait for the emulator to start

--- a/src/examples/override-machine-resource-class.yml
+++ b/src/examples/override-machine-resource-class.yml
@@ -1,6 +1,5 @@
 description: |
-  An example of overriding the android-machine
-  executor's default resource class
+  An example of overriding the android-machine executor's default resource class
 usage:
   version: 2.1
   orbs:

--- a/src/examples/override-machine-resource-class.yml
+++ b/src/examples/override-machine-resource-class.yml
@@ -1,0 +1,14 @@
+description: |
+  An example of overriding the android-machine
+  executor's default resource class
+usage:
+  version: 2.1
+  orbs:
+    android: circleci/android@1.0
+  workflows:
+    test:
+      jobs:
+        - android/run-ui-tests:
+            executor:
+              name: android/android-machine
+              resource-class: xlarge

--- a/src/examples/run-ui-tests-job.yml
+++ b/src/examples/run-ui-tests-job.yml
@@ -1,9 +1,8 @@
 description: |
   An simple example of using the run-ui-tests job,
   using most of the default parameters.
-  Parameters like the system-image and emulator
-  options (e.g. "no-window") may need to be
-  adjusted from the defaults, according to your project.
+  Parameters like the system-image and emulator options (e.g. "no-window")
+  may need to be adjusted from the defaults, according to your project.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/start-emulator-and-run-tests.yml
+++ b/src/examples/start-emulator-and-run-tests.yml
@@ -1,0 +1,22 @@
+description: |
+  An simple example of using the start-emulator-and-run-tests command
+  in a job, using most of the default parameters.
+  Parameters like the system-image and emulator options (e.g. "no-window")
+  may need to be adjusted from the defaults, according to your project.
+usage:
+  version: 2.1
+  orbs:
+    android: circleci/android@1.0
+  jobs:
+    test:
+      executor:
+        name: android/android-machine
+        resource-class: xlarge
+      steps:
+        - checkout
+        - android/start-emulator-and-run-tests:
+            system-image: "system-images;android-29;default;x86"
+  workflows:
+    test:
+      jobs:
+        - test

--- a/src/examples/test-matrix.yml
+++ b/src/examples/test-matrix.yml
@@ -1,0 +1,16 @@
+description: |
+  An simple example of using a test matrix to test on different
+  emulators.
+usage:
+  version: 2.1
+  orbs:
+    android: circleci/android@1.0
+  workflows:
+    test:
+      jobs:
+        - android/run-ui-tests:
+            name: "ui-tests-<<matrix.system-image>>"
+            matrix:
+              parameters:
+                system-image: ["system-images;android-28;default;x86", "system-images;android-29;default;x86"]
+

--- a/src/examples/ui-tests.yml
+++ b/src/examples/ui-tests.yml
@@ -1,0 +1,15 @@
+description: |
+  An simple example of using the run-ui-tests job,
+  using most of the default parameters.
+  Parameters like the system-image and emulator
+  options (e.g. "no-window") may need to be
+  adjusted from the defaults, according to your project.
+usage:
+  version: 2.1
+  orbs:
+    android: circleci/android@1.0
+  workflows:
+    test:
+      jobs:
+        - android/run-ui-tests:
+            system-image: "system-images;android-28;default;x86"

--- a/src/executors/android-machine.yml
+++ b/src/executors/android-machine.yml
@@ -14,7 +14,8 @@ parameters:
   resource-class:
     description: |
       Resource class used for the executor. It is recommended
-      to use large and above to avoid memory issues.
+      to use large and above to avoid memory issues such as process
+      crashes when running emulator tests.
     type: enum
     default: large
     enum: [medium, large, xlarge, 2xlarge]

--- a/src/executors/android-machine.yml
+++ b/src/executors/android-machine.yml
@@ -1,5 +1,6 @@
 description: |
-  This selects an Android machine image. CircleCI's Android machine images are recommended for Android emulator tests.
+  This selects an Android machine image.
+  CircleCI's Android machine images are recommended for Android emulator tests.
   Currently, this defaults to the first Android machine image, which is currently
   in preview status: https://github.com/CircleCI-Public/android-image-preview-docs
 machine:

--- a/src/executors/android-machine.yml
+++ b/src/executors/android-machine.yml
@@ -1,0 +1,20 @@
+description: |
+  This selects an Android machine image. CircleCI's Android machine images are recommended for Android emulator tests.
+  Currently, this defaults to the first Android machine image, which is currently
+  in preview status: https://github.com/CircleCI-Public/android-image-preview-docs
+machine:
+  image: << parameters.image-name >>
+  resource_class: << parameters.resource-class >>
+parameters:
+  image-name:
+    description: |
+      Name of CircleCI Android machine image to use
+    type: string
+    default: "android:202102-01"
+  resource-class:
+    description: |
+      Resource class used for the executor. It is recommended
+      to use large and above to avoid memory issues.
+    type: enum
+    default: large
+    enum: [medium, large, xlarge, 2xlarge]

--- a/src/jobs/run-ui-tests.yml
+++ b/src/jobs/run-ui-tests.yml
@@ -1,6 +1,6 @@
 description: |
-  Run Android UI tests. This is a job that wraps the
-  "start-emulator-and-run-tests" command.
+  Creates an AVD, starts an emulator and runs Android UI tests.
+  This is a job that wraps the "start-emulator-and-run-tests" command.
 parameters:
   executor:
     description: Executor for the job

--- a/src/jobs/run-ui-tests.yml
+++ b/src/jobs/run-ui-tests.yml
@@ -1,0 +1,213 @@
+description: |
+  Run Android UI tests
+parameters:
+  executor:
+    type: executor
+    description: Executor for the job
+    default: android-machine
+  checkout:
+    type: boolean
+    default: true
+    description: Whether to run the checkout step
+  job-pre-steps:
+    type: steps
+    default: []
+  job-post-steps:
+    type: steps
+    default: []
+  avd-name:
+    type: string
+    description: |
+      The name of the AVD to create
+    default: test
+  system-image:
+    type: string
+    description: |
+      Name of system image e.g. "system-images;android-29;default;x86"
+    default: system-images;android-29;default;x86
+  install-system-image:
+    type: boolean
+    description: |
+      Whether to first install the system image via sdkmanager
+    default: true
+  additional-avd-args:
+    type: string
+    default: ""
+    description: |
+      Additional args to be passed directly to the avd creation command
+  gpu:
+    type: string
+    default: "swiftshader_indirect"
+    description: |
+      The value to use for the "-gpu" flag.
+      If set to "", the emulator will be run without the -gpu flag.
+  camera-front:
+    type: string
+    default: "none"
+    description: |
+      The value to use for the "-camera-front" flag.
+      If set to "", the emulator will be run without the -camera-front flag.
+  camera-back:
+    type: string
+    default: "none"
+    description: |
+      The value to use for the "-camera-back" flag.
+      If set to "", the emulator will be run without the -camera-back flag.
+  memory:
+    type: integer
+    default: -1
+    description: |
+      The value to use for the "-memory" flag.
+      If set to -1, the emulator will be run without the -memory flag.
+  no-window:
+    type: boolean
+    default: true
+    description: |
+      Whether to run the emulator with the -no-window flag
+  no-audio:
+    type: boolean
+    default: true
+    description: |
+      Whether to run the emulator with the -noaudio flag
+  no-boot-anim:
+    type: boolean
+    default: true
+    description: |
+      Whether to run the emulator with the -no-boot-anim flag
+  no-snapshot:
+    type: boolean
+    default: true
+    description: |
+      Whether to run the emulator with the -no-snapshot flag
+  delay-adb:
+    type: boolean
+    default: true
+    description: |
+      Whether to run the emulator with the -delay-adb flag
+  verbose:
+    type: boolean
+    default: true
+    description: |
+      Whether to run the emulator with the -verbose flag
+  additional-emulator-args:
+    type: string
+    default: ""
+    description: |
+      Additional args to be passed directly to the emulator command
+  override-emulator-args:
+    type: string
+    default: ""
+    description: |
+      If this is set to a non-blank value, the emulator command will be
+      run with the -avd flag and the value of "override-args" (i.e. none of the defaults
+      provided by the orb command will be used)
+  pre-emulator-wait-steps:
+    description: |
+      Steps to execute while before beginning to wait for the emulator to start up
+    type: steps
+    default: []
+  post-emulator-launch-assemble-command:
+    description: |
+      If this is set to a non-blank value, the configured command will be run
+      after the emulator has been launched, and before commencing the
+      wait for the emulator to finish starting up.
+    type: string
+    default: "./gradlew assembleDebugAndroidTest"
+  restore-gradle-cache-post-emulator-launch:
+    description: |
+      Whether to restore the gradle cache after the emulator has been launched,
+      and before commencing the wait for the emulator to finish starting up.
+    type: boolean
+    default: true
+  restore-gradle-cache-key:
+    description: |
+      Cache key used if the "restore-gradle-cache-post-emulator-launch" parameter
+      is set to true.
+    type: string
+    default: "v1"
+  post-emulator-wait-steps:
+    description: |
+      Steps to execute after waiting for the emulator to start up
+    type: steps
+    default: []
+  wait-for-emulator:
+    type: boolean
+    default: true
+    description: |
+      Wait for the emulator to start up
+  run-logcat:
+    type: boolean
+    default: false
+    description: |
+      Run with logcat in the background, after the emulator starts up
+  disable-animations:
+    type: boolean
+    default: true
+    description: |
+      Disable animations that may interfere with tests, after the emulator starts up
+  pre-run-tests-steps:
+    type: steps
+    default: []
+  post-run-tests-steps:
+    type: steps
+    default: []
+  test-command:
+    description: Command to run in order to run the tests
+    type: string
+    default: "./gradlew connectedDebugAndroidTest"
+  run-tests-working-directory:
+    description: Working directory to run the tests in
+    type: string
+    default: "."
+  max-tries:
+    type: integer
+    default: 2
+  retry-interval:
+    type: integer
+    description: Duration in seconds to wait before the next try
+    default: 5
+executor: << parameters.executor >>
+steps:
+  - << parameters.job-pre-steps >>
+  - when:
+      condition: << parameters.checkout >>
+      steps:
+        - checkout
+  - create-avd:
+      avd-name: << parameters.avd-name >>
+      system-image: <<parameters.system-image>>
+      install: << parameters.install-system-image >>
+      additional-args: << parameters.additional-avd-args >>
+  - start-emulator:
+      avd-name: << parameters.avd-name >>
+      gpu: << parameters.gpu >>
+      camera-front: << parameters.camera-front >>
+      camera-back: << parameters.camera-back >>
+      memory: << parameters.memory >>
+      no-window: << parameters.no-window >>
+      no-audio: << parameters.no-audio >>
+      no-boot-anim: << parameters.no-boot-anim >>
+      no-snapshot: << parameters.no-snapshot >>
+      delay-adb: << parameters.delay-adb >>
+      verbose: << parameters.verbose >>
+      additional-args: << parameters.additional-emulator-args >>
+      override-args: << parameters.override-emulator-args >>
+      wait-for-emulator: << parameters.wait-for-emulator >>
+      pre-emulator-wait-steps: << parameters.pre-emulator-wait-steps >>
+      post-emulator-launch-assemble-command: << parameters.post-emulator-launch-assemble-command >>
+      restore-gradle-cache-post-emulator-launch: << parameters.restore-gradle-cache-post-emulator-launch >>
+      post-emulator-wait-steps: << parameters.post-emulator-wait-steps >>
+      run-logcat: << parameters.run-logcat >>
+      restore-gradle-cache-key: << parameters.restore-gradle-cache-key >>
+      disable-animations: << parameters.disable-animations >>
+  - run-tests:
+      pre-steps: << parameters.pre-run-tests-steps >>
+      post-steps: << parameters.post-run-tests-steps >>
+      working-directory: << parameters.run-tests-working-directory >>
+      test-command: << parameters.test-command >>
+      max-tries: << parameters.max-tries >>
+      retry-interval: << parameters.retry-interval >>
+  - save-gradle-cache:
+      cache-key: << parameters.restore-gradle-cache-key >>
+  - kill-emulators
+  - << parameters.job-post-steps >>

--- a/src/jobs/run-ui-tests.yml
+++ b/src/jobs/run-ui-tests.yml
@@ -120,9 +120,9 @@ parameters:
       and before commencing the wait for the emulator to finish starting up.
     type: boolean
     default: true
-  restore-gradle-cache-key:
+  restore-gradle-cache-prefix:
     description: |
-      Cache key used if the "restore-gradle-cache-post-emulator-launch" parameter
+      Cache prefix used if the "restore-gradle-cache-post-emulator-launch" parameter
       is set to true.
     type: string
     default: "v1"
@@ -212,7 +212,7 @@ steps:
       restore-gradle-cache-post-emulator-launch: << parameters.restore-gradle-cache-post-emulator-launch >>
       post-emulator-wait-steps: << parameters.post-emulator-wait-steps >>
       run-logcat: << parameters.run-logcat >>
-      restore-gradle-cache-key: << parameters.restore-gradle-cache-key >>
+      restore-gradle-cache-prefix: << parameters.restore-gradle-cache-prefix >>
       save-gradle-cache: << parameters.save-gradle-cache >>
       disable-animations: << parameters.disable-animations >>
       pre-run-tests-steps: << parameters.pre-run-tests-steps >>

--- a/src/jobs/run-ui-tests.yml
+++ b/src/jobs/run-ui-tests.yml
@@ -126,6 +126,12 @@ parameters:
       is set to true.
     type: string
     default: "v1"
+  restore-gradle-cache-find-args:
+    description: |
+      Use this to customize how the find command is used to look for relevant
+      file changes.
+    type: string
+    default: ". -name 'build.gradle'"
   save-gradle-cache:
     description: |
       Whether to write to the gradle cache after the tests have run
@@ -213,6 +219,7 @@ steps:
       post-emulator-wait-steps: << parameters.post-emulator-wait-steps >>
       run-logcat: << parameters.run-logcat >>
       restore-gradle-cache-prefix: << parameters.restore-gradle-cache-prefix >>
+      restore-gradle-cache-find-args: << parameters.restore-gradle-cache-find-args >>
       save-gradle-cache: << parameters.save-gradle-cache >>
       disable-animations: << parameters.disable-animations >>
       pre-run-tests-steps: << parameters.pre-run-tests-steps >>

--- a/src/jobs/run-ui-tests.yml
+++ b/src/jobs/run-ui-tests.yml
@@ -3,105 +3,100 @@ description: |
   "start-emulator-and-run-tests" command.
 parameters:
   executor:
-    type: executor
     description: Executor for the job
+    type: executor
     default: android-machine
   checkout:
+    description: Whether to run the checkout step
     type: boolean
     default: true
-    description: Whether to run the checkout step
-  job-pre-steps:
-    type: steps
-    default: []
-  job-post-steps:
-    type: steps
-    default: []
   avd-name:
-    type: string
     description: |
       The name of the AVD to create
+    type: string
     default: test
   system-image:
-    type: string
     description: |
-      Name of system image e.g. "system-images;android-29;default;x86"
+      Name of system image e.g. "system-images;android-29;default;x86".
+      It should match the name seen in the "sdkmanager --list" output.
+    type: string
     default: system-images;android-29;default;x86
   install-system-image:
-    type: boolean
     description: |
       Whether to first install the system image via sdkmanager
+    type: boolean
     default: true
   additional-avd-args:
-    type: string
-    default: ""
     description: |
       Additional args to be passed directly to the avd creation command
-  gpu:
     type: string
-    default: "swiftshader_indirect"
+    default: ""
+  gpu:
     description: |
       The value to use for the "-gpu" flag.
       If set to "", the emulator will be run without the -gpu flag.
-  camera-front:
     type: string
-    default: "none"
+    default: "swiftshader_indirect"
+  camera-front:
     description: |
       The value to use for the "-camera-front" flag.
       If set to "", the emulator will be run without the -camera-front flag.
-  camera-back:
     type: string
-    default: "none"
+    default: ""
+  camera-back:
     description: |
       The value to use for the "-camera-back" flag.
       If set to "", the emulator will be run without the -camera-back flag.
+    type: string
+    default: ""
   memory:
-    type: integer
-    default: -1
     description: |
       The value to use for the "-memory" flag.
       If set to -1, the emulator will be run without the -memory flag.
+    type: integer
+    default: -1
   no-window:
-    type: boolean
-    default: true
     description: |
       Whether to run the emulator with the -no-window flag
-  no-audio:
     type: boolean
     default: true
+  no-audio:
     description: |
       Whether to run the emulator with the -noaudio flag
-  no-boot-anim:
     type: boolean
     default: true
+  no-boot-anim:
     description: |
       Whether to run the emulator with the -no-boot-anim flag
-  no-snapshot:
     type: boolean
     default: true
+  no-snapshot:
     description: |
       Whether to run the emulator with the -no-snapshot flag
-  delay-adb:
     type: boolean
     default: true
+  delay-adb:
     description: |
       Whether to run the emulator with the -delay-adb flag
-  verbose:
     type: boolean
     default: true
+  verbose:
     description: |
       Whether to run the emulator with the -verbose flag
+    type: boolean
+    default: true
   additional-emulator-args:
-    type: string
-    default: ""
     description: |
       Additional args to be passed directly to the emulator command
-  override-emulator-args:
     type: string
     default: ""
+  override-emulator-args:
     description: |
       If this is set to a non-blank value, the emulator command will be
       run with the -avd flag and the value of "override-args" (i.e. none of the defaults
       provided by the orb command will be used)
+    type: string
+    default: ""
   pre-emulator-wait-steps:
     description: |
       Steps to execute while before beginning to wait for the emulator to start up
@@ -143,24 +138,28 @@ parameters:
     type: steps
     default: []
   wait-for-emulator:
+    description: |
+      Whether to wait for the emulator to start up
     type: boolean
     default: true
-    description: |
-      Wait for the emulator to start up
   run-logcat:
+    description: |
+      Whether to run with logcat in the background, after the emulator starts up
     type: boolean
     default: false
-    description: |
-      Run with logcat in the background, after the emulator starts up
   disable-animations:
+    description: |
+      Whether to disable animations that may interfere with tests, after the emulator starts up
     type: boolean
     default: true
-    description: |
-      Disable animations that may interfere with tests, after the emulator starts up
   pre-run-tests-steps:
+    description: |
+      Steps to run before the tests
     type: steps
     default: []
   post-run-tests-steps:
+    description: |
+      Steps to run after the tests
     type: steps
     default: []
   test-command:
@@ -172,25 +171,25 @@ parameters:
     type: string
     default: "."
   max-tries:
+    description: Max number of tries. To disable retries, set this to 1.
     type: integer
     default: 2
   retry-interval:
-    type: integer
     description: Duration in seconds to wait before the next try
+    type: integer
     default: 5
   no-output-timeout:
-    type: string
     description: |
       Use this to configure the no_output_timeout value of the test run
+    type: string
     default: 10m
   kill-emulators:
-    type: boolean
     description: |
       Whether to kill the emulators after the tests complete
+    type: boolean
     default: true
 executor: << parameters.executor >>
 steps:
-  - << parameters.job-pre-steps >>
   - when:
       condition: << parameters.checkout >>
       steps:
@@ -230,4 +229,3 @@ steps:
       retry-interval: << parameters.retry-interval >>
       no-output-timeout: << parameters.no-output-timeout >>
       kill-emulators: << parameters.kill-emulators >>
-  - << parameters.job-post-steps >>


### PR DESCRIPTION
The new [Android machine image](https://github.com/CircleCI-Public/android-image-preview-docs) (currently in preview status) has support for running emulators. This PR adds new commands and a job to support running UI tests.

**Additions**
- New commands:
  - `create-avd` for creating an AVD
  - `disable-animations` to disable emulator animations
  - `kill-emulators` command to kill emulator processes
  - `restore-gradle-cache` and `save-gradle-cache`
  - `run-tests` to run tests, with retries supported
  - `start-emulator` to start an emulator from an existing AVD
  - `wait-for-emulator` to wait for an emulator to start up
  - `start-emulator-and-run-tests`: a command that wraps `create-avd`, `start-emulator` and `run-tests`
 - New job: `run-ui-tests` that wraps the `start-emulator-and-run-tests` command
 - New executor: `android-machine`
 - New examples

**Modifications to existing commands**
  - Updated description of `accept-licenses` and `install-ndk` commands
  - Added `cache-prefix` parameter to `restore-build-cache` and `save-build-cache` commands so that the cache prefix can be customized if needed. Since it defaults to `v1`, the commands should still work the way they did before, by default.