### PR TITLE
[semver: patch] Add more annotations to orb examples

### DIFF
--- a/src/examples/granular-commands.yml
+++ b/src/examples/granular-commands.yml
@@ -1,0 +1,39 @@
+description: |
+  An example of using the more granular commands of the orb together,
+  to achieve something similar to using the "start-emulator-and-run-tests" command
+  or the "run-ui-tests" job.
+usage:
+  version: 2.1
+  orbs:
+    android: circleci/android@1.0
+  jobs:
+    test:
+      executor:
+        name: android/android-machine
+        resource-class: large
+      steps:
+        - checkout
+        # Create an AVD named "myavd"
+        - android/create-avd:
+            avd-name: myavd
+            system-image: system-images;android-29;default;x86
+            install: true
+        # By default, after starting up the emulator, a cache will be restored,
+        # "./gradlew assembleDebugAndroidTest" will be run and then a script
+        # will be run to wait for the emulator to start up.
+        # Specify the "post-emulator-launch-assemble-command" command to override
+        # the gradle command run, or set "wait-for-emulator" to false to disable
+        # waiting for the emulator altogether.
+        - android/start-emulator:
+            avd-name: myavd
+            no-window: true
+            restore-gradle-cache-prefix: v1a
+        # Runs "./gradlew connectedDebugAndroidTest" by default.
+        # Specify the "test-command" parameter to customize the command run.
+        - android/run-tests
+        - android/save-gradle-cache:
+            cache-prefix: v1a
+  workflows:
+    test:
+      jobs:
+        - test

--- a/src/examples/run-ui-tests-job.yml
+++ b/src/examples/run-ui-tests-job.yml
@@ -11,4 +11,6 @@ usage:
     test:
       jobs:
         - android/run-ui-tests:
+            # Specify job "pre-steps" and "post-steps" if necessary
+            # to execute custom steps before and afer any of the built-in steps
             system-image: "system-images;android-28;default;x86"

--- a/src/examples/start-emulator-and-run-tests.yml
+++ b/src/examples/start-emulator-and-run-tests.yml
@@ -11,11 +11,25 @@ usage:
     test:
       executor:
         name: android/android-machine
-        resource-class: xlarge
+        resource-class: large
       steps:
         - checkout
+        # Creates an AVD and starts up the emulator using the AVD.
+        # While the emulator is starting up, the gradle cache will
+        # be restored and the Android app will be assembled.
+        # When the emulator is ready, UI tests will be run.
+        # After the tests are run, the gradle cache will be saved (if it
+        # hasn't been saved before)
         - android/start-emulator-and-run-tests:
-            system-image: "system-images;android-29;default;x86"
+            system-image: system-images;android-29;default;x86
+        #   The cache prefix can be overridden
+        #   restore-gradle-cache-prefix: v1a
+        #
+        #   The command to be run, while waiting for emulator startup, can be overridden
+        #   post-emulator-launch-assemble-command: ./gradlew assembleDebugAndroidTest
+        #
+        #   The test command can be overridden
+        #   test-command: ./gradlew connectedDebugAndroidTest
   workflows:
     test:
       jobs:


### PR DESCRIPTION
- Add more annotations to orb examples
- Add example of using more granular commands
