### PR TITLE
[semver:patch] Improve naming of cache commands

### DIFF
--- a/src/commands/restore-build-cache.yml
+++ b/src/commands/restore-build-cache.yml
@@ -9,4 +9,5 @@ parameters:
 
 steps:
   - restore_cache:
+      name: Restore build cache
       key: android-orb-<<parameters.cache-prefix>>-

--- a/src/commands/restore-gradle-cache.yml
+++ b/src/commands/restore-gradle-cache.yml
@@ -18,4 +18,5 @@ steps:
         find << parameters.find-args >> | sort | xargs cat |
         shasum | awk '{print $1}' > /tmp/gradle_cache_seed
   - restore_cache:
+      name: Restore gradle cache
       key: gradle-<< parameters.cache-prefix>>-{{ arch }}-{{ checksum "/tmp/gradle_cache_seed" }}

--- a/src/commands/save-build-cache.yml
+++ b/src/commands/save-build-cache.yml
@@ -18,6 +18,7 @@ parameters:
 
 steps:
   - save_cache:
+      name: Save build cache
       key: android-orb-<<parameters.cache-prefix>>-{{ epoch }}
       paths:
         - ~/.android/build-cache

--- a/src/commands/save-gradle-cache.yml
+++ b/src/commands/save-gradle-cache.yml
@@ -7,6 +7,7 @@ parameters:
     default: v1
 steps:
   - save_cache:
+      name: Save gradle cache
       key: gradle-<< parameters.cache-prefix>>-{{ arch }}-{{ checksum "/tmp/gradle_cache_seed" }}
       paths:
         - ~/.gradle/caches


### PR DESCRIPTION
Improve naming of the cache commands as displayed in the builds, so that the restore/save gradle/build cache commands are more distinguishable from each other