### PR TITLE
[semver:patch] Default delay-adb to false to improve support for older API levels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,7 +468,7 @@ workflows:
                   rm -rf compose-samples
           matrix:
             parameters:
-              system-image: ["system-images;android-29;default;x86", "system-images;android-29;google_apis;x86_64"]
+              system-image: ["system-images;android-29;default;x86", "system-images;android-29;google_apis;x86_64", "system-images;android-25;default;x86"]
 
       - test-emulator-commands:
           system-image: "system-images;android-29;default;x86"

--- a/src/commands/start-emulator-and-run-tests.yml
+++ b/src/commands/start-emulator-and-run-tests.yml
@@ -72,7 +72,7 @@ parameters:
     description: |
       Whether to run the emulator with the -delay-adb flag
     type: boolean
-    default: true
+    default: false
   verbose:
     description: |
       Whether to run the emulator with the -verbose flag

--- a/src/commands/start-emulator.yml
+++ b/src/commands/start-emulator.yml
@@ -55,7 +55,7 @@ parameters:
     description: |
       Whether to run the emulator with the -delay-adb flag
     type: boolean
-    default: true
+    default: false
   verbose:
     description: |
       Whether to run the emulator with the -verbose flag

--- a/src/jobs/run-ui-tests.yml
+++ b/src/jobs/run-ui-tests.yml
@@ -2,6 +2,26 @@ description: |
   Creates an AVD, starts an emulator and runs Android UI tests.
   This is a job that wraps the "start-emulator-and-run-tests" command.
 parameters:
+  test-command:
+    description: Command to run in order to run the tests
+    type: string
+    default: "./gradlew connectedDebugAndroidTest"
+  system-image:
+    description: |
+      Name of system image e.g. "system-images;android-29;default;x86".
+      It should match the name seen in the "sdkmanager --list" output.
+    type: string
+    default: system-images;android-29;default;x86
+  pre-run-tests-steps:
+    description: |
+      Steps to run before the tests
+    type: steps
+    default: []
+  post-run-tests-steps:
+    description: |
+      Steps to run after the tests
+    type: steps
+    default: []
   executor:
     description: Executor for the job
     type: executor
@@ -15,12 +35,6 @@ parameters:
       The name of the AVD to create
     type: string
     default: test
-  system-image:
-    description: |
-      Name of system image e.g. "system-images;android-29;default;x86".
-      It should match the name seen in the "sdkmanager --list" output.
-    type: string
-    default: system-images;android-29;default;x86
   install-system-image:
     description: |
       Whether to first install the system image via sdkmanager
@@ -79,7 +93,7 @@ parameters:
     description: |
       Whether to run the emulator with the -delay-adb flag
     type: boolean
-    default: true
+    default: false
   verbose:
     description: |
       Whether to run the emulator with the -verbose flag
@@ -152,20 +166,6 @@ parameters:
       Whether to disable animations that may interfere with tests, after the emulator starts up
     type: boolean
     default: true
-  pre-run-tests-steps:
-    description: |
-      Steps to run before the tests
-    type: steps
-    default: []
-  post-run-tests-steps:
-    description: |
-      Steps to run after the tests
-    type: steps
-    default: []
-  test-command:
-    description: Command to run in order to run the tests
-    type: string
-    default: "./gradlew connectedDebugAndroidTest"
   run-tests-working-directory:
     description: Working directory to run the tests in
     type: string


### PR DESCRIPTION
- Change default value of `-delay-adb` to false as when set to true, it can cause the emulator to not finish starting up, for system images with older API levels (typically <26). See example of failed job: https://app.circleci.com/pipelines/github/CircleCI-Public/android-orb/107/workflows/0c44a7a3-a223-492d-be02-dc9ce5181375/jobs/1731
- Rearrange parameter listing of `run-ui-tests` job for easier referencing of most-used parameters