### PR TITLE
By default, fail the build immediately when the tests fail

### DIFF
--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -10,9 +10,9 @@ parameters:
     type: string
     default: "."
   max-tries:
-    description: Max number of tries. To disable retries, set this to 1.
+    description: Max number of tries. To enable retries, set this to > 1.
     type: integer
-    default: 2
+    default: 1
   retry-interval:
     description: Duration in seconds to wait before the next try
     type: integer


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This change makes it so that, by default,  when your tests fail, they don't have to run and then fail again before the build fails. 

This seems like reasonable expected behavior to me, but then again, I have been wrong with regard to matters of taste once or twice in my life.

### Description

Change the `run-tests` command to, by default, fail immediately when the tests fail.