### PR TITLE
[semver:minor] Add parameter resource-class for android docker executor

### DIFF
--- a/src/executors/android.yml
+++ b/src/executors/android.yml
@@ -21,5 +21,12 @@ parameters:
       Choose an optional Android image variant, either node or ndk:
       https://hub.docker.com/r/circleci/android/tags
 
+  resource-class:
+    description: Resource class used for the executor.
+    type: enum
+    default: medium
+    enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+
 docker:
   - image: circleci/android:api-<<parameters.sdk-version>><<#parameters.variant>>-<<parameters.variant>><</parameters.variant>>
+resource_class: << parameters.resource-class >>

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -4,6 +4,7 @@ description: >
 executor:
   name: android
   sdk-version: "23"
+  resource-class: medium
 
 steps:
   - checkout


### PR DESCRIPTION
As same as Android Machine executor, I added `resource-class` parameter for Docker Executor 

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
