### PR TITLE
Add command to change OpenJDK versions from 11 to 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,14 +16,10 @@ workflows:
       - orb-tools/pack:
           filters: *filters
       - orb-tools/review:
-          exclude: RC009 #Complex Run step's commands should be imported.
+          exclude: RC009
           filters: *filters
       - shellcheck/check:
           exclude: SC2148,SC2038,SC2086,SC2002,SC2016
-          #SC2148: Include a shebang (#!) to specify the shell.
-          #SC2086 Double quote to prevent globbing and word splitting.
-          #SC2002: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
-          #SC2016: Expressions don't expand in single quotes, use double quotes for that.
           filters: *filters
       - orb-tools/publish:
           orb-name: circleci/android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,14 @@ workflows:
       - orb-tools/pack:
           filters: *filters
       - orb-tools/review:
-          exclude: RC009
+          exclude: RC009 #Complex Run step's commands should be imported.
           filters: *filters
       - shellcheck/check:
           exclude: SC2148,SC2038,SC2086,SC2002,SC2016
+          #SC2148: Include a shebang (#!) to specify the shell.
+          #SC2086 Double quote to prevent globbing and word splitting.
+          #SC2002: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+          #SC2016: Expressions don't expand in single quotes, use double quotes for that.
           filters: *filters
       - orb-tools/publish:
           orb-name: circleci/android

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -37,6 +37,8 @@ jobs:
           java-version: << parameters.java-version >>
       - run:
           command: |
+            JAVA_VER="$( java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 )"
+            JAVAC_VER="$( javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1 )"
             if [ "$JAVA_VER" -ne <<parameters.java-version>> ] || [ "$JAVAC_VER" -ne <<parameters.java-version>> ]; then
               echo "Job failed because either the java version or javac version was not changed."
               exit 1

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -18,25 +18,25 @@ prod-deploy-requires: &prod-deploy-requires
   ]
 
 jobs:
-  test-ndk-install:
+  test-ndk-install: #test installs the Android NDK toolkit
     parameters:
-      executor:
+      executor: #defines the environment to run the job in the parameters, to be called later in the executor child
         type: executor
         description: |
           Which Android image/executor to use. Choose between 'android-docker'
           and 'android-machine'.
-      ndk:
+      ndk: #declares the NDK version to be installed
         type: string
         description: ndk version to install
     executor: << parameters.executor >>
-    steps:
-      - checkout
+    steps: 
+      - checkout #a special step used to check out source code to the configured path
       - android/install-ndk:
-          version: << parameters.ndk >>
+          version: << parameters.ndk >> #uses the ndk parameter to declare the version
 
   test-emulator-commands:
     parameters:
-      system-image:
+      system-image: #parameter to declare the system image for the Android Virtual Device
         type: string
       tag:
         type: string
@@ -47,70 +47,71 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Clone project
+          name: Clone project #clones a github project then enters the directory and checks out a branch
           command: |
-            git clone https://github.com/android/compose-samples
+            git clone https://github.com/android/compose-samples 
             cd compose-samples
             # pin the revision for consistency
             git checkout f1e930dbe6f209dde9ceb5d3419bbf314aabcb58
-      - android/create-avd:
+      - android/create-avd: #creates an Android Virtual Device named test1
           avd-name: test1
-          system-image: <<parameters.system-image>>
-          install: true
-      - android/start-emulator:
+          system-image: <<parameters.system-image>> #takes system-image version from the parameters
+          install: true #true installs image via sdk manager
+      - android/start-emulator: #starts the Android Virtual Device
           avd-name: test1
-          run-logcat: true
-          memory: 3072
+          run-logcat: true #runs logcat in background for logging
+          memory: 3072 #declares allocated memory allowed
           restore-gradle-cache-prefix: v1-multiple
           post-emulator-launch-assemble-command: "cd compose-samples/Owl && ./gradlew assembleDebugAndroidTest && cd ../Jetsnack && ./gradlew assembleDebugAndroidTest"
-      - android/run-tests:
-          working-directory: ./compose-samples/Owl
-      - android/run-tests:
+          #command ran after the emulator is launched
+      - android/run-tests: #runs tests in the emulator
+          working-directory: ./compose-samples/Owl #declares the directory the tests are run in
+      - android/run-tests: #same as above
           working-directory: ./compose-samples/Jetsnack
       - android/save-gradle-cache:
-          cache-prefix: v1-multiple
-      - android/kill-emulators
+          cache-prefix: v1-multiple #cache prefix to add to the key
+      - android/kill-emulators #kills all running emulators
       - run: sdkmanager "system-images;android-28;default;x86"
-      - android/create-avd:
+      - android/create-avd: #creates a second test AVD
           avd-name: test2
           system-image: system-images;android-28;default;x86
-          install: false
+          install: false #does not install via the sdkmanager
       - android/start-emulator:
           avd-name: test2
           # we expect the no-window parameter to be overriden by override-args
-          no-window: true
-          override-args: "-delay-adb -verbose -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim"
-          wait-for-emulator: true
-          restore-gradle-cache-post-emulator-launch: false
+          no-window: true #has the emulator run with the -no-window tag
+          override-args: "-delay-adb -verbose -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim" #runs the avd with these override args
+          wait-for-emulator: true #waits for the emulator to start before continuing
+          restore-gradle-cache-post-emulator-launch: false #does not restore gradle after the emulator starts
           post-emulator-launch-assemble-command: ""
-          disable-animations: false
-          pre-emulator-wait-steps:
+          disable-animations: false #does not disable animations that may interfere with tests
+          pre-emulator-wait-steps: #steps to run before the emulator is started up
             - run:
                 name: Dummy pre-emulator-wait-steps
                 command: |
                   echo "Test"
-          post-emulator-wait-steps:
+          post-emulator-wait-steps: #steps that run after the emulator starts up
             - run:
                 name: Dummy post-emulator-wait-steps
                 command: |
                   echo "Test"
-      - android/kill-emulators
+      - android/kill-emulators #kills emulator
 
   test-start-emulator-and-run-tests:
     parameters:
-      tag:
+      tag: #tag for the android image to be used
         type: string
         description: "Android machine image tag to use."
-    executor:
+    executor: #executor for the android machine, image, and size of executor
       name: android/android-machine
       tag: << parameters.tag >>
       resource-class: xlarge
     steps:
       - checkout
       - android/start-emulator-and-run-tests:
-          pre-emulator-wait-steps:
+          pre-emulator-wait-steps: #commands that run before emulator starts
             - run:
-                name: Clone project
+                name: Clone project #clones a project then checkouts a branch
                 command: |
                     git clone https://github.com/android/compose-samples
                     cd compose-samples
@@ -119,14 +120,14 @@ jobs:
             - android/restore-build-cache
             - run: cd compose-samples/Jetchat && ./gradlew assembleDebugAndroidTest
           post-emulator-launch-assemble-command: ""
-          run-tests-working-directory: ./compose-samples/Jetchat
-          post-run-tests-steps:
+          run-tests-working-directory: ./compose-samples/Jetchat #declares working directory for tests
+          post-run-tests-steps: #steps after commands are run
             - android/save-build-cache  
 
 workflows:
   test-deploy:
     jobs:
-      - test-ndk-install:
+      - test-ndk-install: #runs the test-ndk-install job with an executor in a docker image
           name: "Test NDK Install on Android Docker"
           matrix:
             parameters:
@@ -140,7 +141,7 @@ workflows:
                 - "21.4.7075529"
                 - "19.2.5345600"
           filters: *filters
-      - test-ndk-install:
+      - test-ndk-install: #runs the test-ndk-install job with an executor in the android machine
           name: "Test NDK Install on Android Machine"
           executor:
             name: android/android-machine
@@ -152,7 +153,7 @@ workflows:
                 - "21.4.7075529"
                 - "19.2.5345600"
           filters: *filters
-      - android/run-ui-tests:
+      - android/run-ui-tests: #runs run-ui-tests from the examples directory
           name: "ui-tests-<<matrix.system-image>>"
           executor:
             name: android/android-machine
@@ -169,7 +170,7 @@ workflows:
                   cd ..
                   cp -r compose-samples/Jetchat/* .
                   rm -rf compose-samples
-          matrix:
+          matrix: #selects a matrix of images to run the ui tests on
             parameters:
               system-image: ["system-images;android-29;default;x86", "system-images;android-29;google_apis;x86_64", "system-images;android-25;default;x86"]
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -14,29 +14,54 @@ prod-deploy-requires: &prod-deploy-requires
     ui-tests-system-images;android-29;default;x86,
     ui-tests-system-images;android-29;google_apis;x86_64,
     test-emulator-commands,
-    test-start-emulator-and-run-tests
+    test-start-emulator-and-run-tests,
+    test-java-version
   ]
 
 jobs:
-  test-ndk-install: #test installs the Android NDK toolkit
+  test-java-version:
     parameters:
-      executor: #defines the environment to run the job in the parameters, to be called later in the executor child
+      executor:
         type: executor
         description: |
           Which Android image/executor to use. Choose between 'android-docker'
           and 'android-machine'.
-      ndk: #declares the NDK version to be installed
+      java-version:
+        type: integer
+        description: |
+          Version to use in the change-java-version job
+    executor: <<parameters.executor>>
+    steps:
+      - checkout
+      - android/change-java-version:
+          java-version: << parameters.java-version >>
+      - run:
+          command: |
+            if [ "$JAVA_VER" -ne <<parameters.java-version>> ] || [ "$JAVAC_VER" -ne <<parameters.java-version>> ]; then
+              echo "Job failed because either the java version or javac version was not changed."
+              exit 1
+            fi
+          name: check for correctness
+  
+  test-ndk-install:
+    parameters:
+      executor:
+        type: executor
+        description: |
+          Which Android image/executor to use. Choose between 'android-docker'
+          and 'android-machine'.
+      ndk:
         type: string
         description: ndk version to install
     executor: << parameters.executor >>
-    steps: 
-      - checkout #a special step used to check out source code to the configured path
+    steps:
+      - checkout
       - android/install-ndk:
-          version: << parameters.ndk >> #uses the ndk parameter to declare the version
+          version: << parameters.ndk >>
 
   test-emulator-commands:
     parameters:
-      system-image: #parameter to declare the system image for the Android Virtual Device
+      system-image:
         type: string
       tag:
         type: string
@@ -47,71 +72,70 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Clone project #clones a github project then enters the directory and checks out a branch
+          name: Clone project
           command: |
-            git clone https://github.com/android/compose-samples 
+            git clone https://github.com/android/compose-samples
             cd compose-samples
             # pin the revision for consistency
             git checkout f1e930dbe6f209dde9ceb5d3419bbf314aabcb58
-      - android/create-avd: #creates an Android Virtual Device named test1
+      - android/create-avd:
           avd-name: test1
-          system-image: <<parameters.system-image>> #takes system-image version from the parameters
-          install: true #true installs image via sdk manager
-      - android/start-emulator: #starts the Android Virtual Device
+          system-image: <<parameters.system-image>>
+          install: true
+      - android/start-emulator:
           avd-name: test1
-          run-logcat: true #runs logcat in background for logging
-          memory: 3072 #declares allocated memory allowed
+          run-logcat: true
+          memory: 3072
           restore-gradle-cache-prefix: v1-multiple
           post-emulator-launch-assemble-command: "cd compose-samples/Owl && ./gradlew assembleDebugAndroidTest && cd ../Jetsnack && ./gradlew assembleDebugAndroidTest"
-          #command ran after the emulator is launched
-      - android/run-tests: #runs tests in the emulator
-          working-directory: ./compose-samples/Owl #declares the directory the tests are run in
-      - android/run-tests: #same as above
+      - android/run-tests:
+          working-directory: ./compose-samples/Owl
+      - android/run-tests:
           working-directory: ./compose-samples/Jetsnack
       - android/save-gradle-cache:
-          cache-prefix: v1-multiple #cache prefix to add to the key
-      - android/kill-emulators #kills all running emulators
+          cache-prefix: v1-multiple
+      - android/kill-emulators
       - run: sdkmanager "system-images;android-28;default;x86"
-      - android/create-avd: #creates a second test AVD
+      - android/create-avd:
           avd-name: test2
           system-image: system-images;android-28;default;x86
-          install: false #does not install via the sdkmanager
+          install: false
       - android/start-emulator:
           avd-name: test2
           # we expect the no-window parameter to be overriden by override-args
-          no-window: true #has the emulator run with the -no-window tag
-          override-args: "-delay-adb -verbose -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim" #runs the avd with these override args
-          wait-for-emulator: true #waits for the emulator to start before continuing
-          restore-gradle-cache-post-emulator-launch: false #does not restore gradle after the emulator starts
+          no-window: true
+          override-args: "-delay-adb -verbose -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim"
+          wait-for-emulator: true
+          restore-gradle-cache-post-emulator-launch: false
           post-emulator-launch-assemble-command: ""
-          disable-animations: false #does not disable animations that may interfere with tests
-          pre-emulator-wait-steps: #steps to run before the emulator is started up
+          disable-animations: false
+          pre-emulator-wait-steps:
             - run:
                 name: Dummy pre-emulator-wait-steps
                 command: |
                   echo "Test"
-          post-emulator-wait-steps: #steps that run after the emulator starts up
+          post-emulator-wait-steps:
             - run:
                 name: Dummy post-emulator-wait-steps
                 command: |
                   echo "Test"
-      - android/kill-emulators #kills emulator
+      - android/kill-emulators
 
   test-start-emulator-and-run-tests:
     parameters:
-      tag: #tag for the android image to be used
+      tag:
         type: string
         description: "Android machine image tag to use."
-    executor: #executor for the android machine, image, and size of executor
+    executor:
       name: android/android-machine
       tag: << parameters.tag >>
       resource-class: xlarge
     steps:
       - checkout
       - android/start-emulator-and-run-tests:
-          pre-emulator-wait-steps: #commands that run before emulator starts
+          pre-emulator-wait-steps:
             - run:
-                name: Clone project #clones a project then checkouts a branch
+                name: Clone project
                 command: |
                     git clone https://github.com/android/compose-samples
                     cd compose-samples
@@ -120,14 +144,25 @@ jobs:
             - android/restore-build-cache
             - run: cd compose-samples/Jetchat && ./gradlew assembleDebugAndroidTest
           post-emulator-launch-assemble-command: ""
-          run-tests-working-directory: ./compose-samples/Jetchat #declares working directory for tests
-          post-run-tests-steps: #steps after commands are run
+          run-tests-working-directory: ./compose-samples/Jetchat
+          post-run-tests-steps:
             - android/save-build-cache  
 
 workflows:
   test-deploy:
     jobs:
-      - test-ndk-install: #runs the test-ndk-install job with an executor in a docker image
+      - test-java-version:
+          name: "Test OpenJDK version change"
+          executor:
+            name: android/android-docker
+            tag: "2021.10.1"
+          matrix:
+            parameters:
+              java-version:
+                - 8
+                - 11
+                - 13
+      - test-ndk-install:
           name: "Test NDK Install on Android Docker"
           matrix:
             parameters:
@@ -141,7 +176,7 @@ workflows:
                 - "21.4.7075529"
                 - "19.2.5345600"
           filters: *filters
-      - test-ndk-install: #runs the test-ndk-install job with an executor in the android machine
+      - test-ndk-install:
           name: "Test NDK Install on Android Machine"
           executor:
             name: android/android-machine
@@ -153,7 +188,7 @@ workflows:
                 - "21.4.7075529"
                 - "19.2.5345600"
           filters: *filters
-      - android/run-ui-tests: #runs run-ui-tests from the examples directory
+      - android/run-ui-tests:
           name: "ui-tests-<<matrix.system-image>>"
           executor:
             name: android/android-machine
@@ -170,7 +205,7 @@ workflows:
                   cd ..
                   cp -r compose-samples/Jetchat/* .
                   rm -rf compose-samples
-          matrix: #selects a matrix of images to run the ui tests on
+          matrix:
             parameters:
               system-image: ["system-images;android-29;default;x86", "system-images;android-29;google_apis;x86_64", "system-images;android-25;default;x86"]
           filters: *filters

--- a/src/commands/change-java-version.yml
+++ b/src/commands/change-java-version.yml
@@ -9,8 +9,11 @@ parameters:
 steps:
   - run:
       command: |
-        JAVA_VER="$( java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 )"
-        if [ "$JAVA_VER" -ne <<parameters.java-version>> ]; then
+        CURRENT_JAVA_VER="$( java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 )"
+        CURRENT_JAVAC_VER="$( javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1 )"
+        echo "Current Java Version: $CURRENT_JAVA_VERSION"
+        echo "Current Java Compiler Version : $CURRENT_JAVAC_VERSTION"
+        if [ "$CURRENT_JAVA_VER" -ne <<parameters.java-version>> ]; then
           if [ <<parameters.java-version>> -eq 8 ] || [ <<parameters.java-version>> -eq 11 ]; then
             if [ <<parameters.java-version>> -eq 8 ]; then
               sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
@@ -24,7 +27,9 @@ steps:
           echo "export JAVA_HOME=/usr/lib/jvm/java-<<parameters.java-version>>-openjdk-amd64" >>~/.bashrc
           echo "export PATH=$JAVA_HOME/bin:$PATH" >>~/.bashrc
         fi
-        JAVA_VER="$( java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 )"
-        JAVAC_VER="$( javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1 )"
+        NEW_JAVA_VER="$( java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 )"
+        NEW_JAVAC_VER="$( javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1 )"
+        echo "New Java Version : $NEW_JAVA_VER"
+        echo "New Java Compiler Version : $NEW_JAVAC_VER"
       name: change OpenJDK version
 

--- a/src/commands/change-java-version.yml
+++ b/src/commands/change-java-version.yml
@@ -1,0 +1,30 @@
+description: |
+  Change default java version from OpenJDK v11.
+parameters:
+  java-version:
+    type: integer
+    default: 8
+    description: |
+      The version of OpenJDK to change to
+steps:
+  - run:
+      command: |
+        JAVA_VER="$( java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 )"
+        if [ "$JAVA_VER" -ne <<parameters.java-version>> ]; then
+          if [ <<parameters.java-version>> -eq 8 ] || [ <<parameters.java-version>> -eq 11 ]; then
+            if [ <<parameters.java-version>> -eq 8 ]; then
+              sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+            else
+              sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+            fi
+            sudo update-alternatives --set javac /usr/lib/jvm/java-<<parameters.java-version>>-openjdk-amd64/bin/javac
+          else
+            sudo apt install openjdk-<<parameters.java-version>>-jdk
+          fi
+          echo "export JAVA_HOME=/usr/lib/jvm/java-<<parameters.java-version>>-openjdk-amd64" >>~/.bashrc
+          echo "export PATH=$JAVA_HOME/bin:$PATH" >>~/.bashrc
+        fi
+        JAVA_VER="$( java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 )"
+        JAVAC_VER="$( javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1 )"
+      name: change OpenJDK version
+

--- a/src/commands/change-java-version.yml
+++ b/src/commands/change-java-version.yml
@@ -11,8 +11,8 @@ steps:
       command: |
         CURRENT_JAVA_VER="$( java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 )"
         CURRENT_JAVAC_VER="$( javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1 )"
-        echo "Current Java Version: $CURRENT_JAVA_VERSION"
-        echo "Current Java Compiler Version : $CURRENT_JAVAC_VERSTION"
+        echo "Current Java Version: $CURRENT_JAVA_VER"
+        echo "Current Java Compiler Version : $CURRENT_JAVAC_VER"
         if [ "$CURRENT_JAVA_VER" -ne <<parameters.java-version>> ]; then
           if [ <<parameters.java-version>> -eq 8 ] || [ <<parameters.java-version>> -eq 11 ]; then
             if [ <<parameters.java-version>> -eq 8 ]; then


### PR DESCRIPTION
Added a new job to allow switch OpenJDK versions per [this issue](https://github.com/CircleCI-Public/android-orb/issues/31)

Description
Wrote a command with 3 steps, the first to check the current OpenJDK version, the second changes the default OpenJDK version of the current image to OpenJDK v8, and the third step confirms the change by running java -version once more
Also, added a parameter that will allow you to change OpenJDK versions, default: '1.8.0'. To check available OpenJDK versions, run `update-java-alternatives --list`