### PR TITLE
fix: Added handling for different paths for ANDROID_NDK_HOME

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -164,6 +164,7 @@ workflows:
                 - 8
                 - 11
                 - 13
+          filters: *filters
       - test-ndk-install:
           name: "Test NDK Install on Android Docker"
           matrix:

--- a/src/commands/install-ndk.yml
+++ b/src/commands/install-ndk.yml
@@ -23,13 +23,18 @@ steps:
         [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo
 
         echo y | sdkmanager "ndk;<< parameters.version >>"
+        android_ndk_home=""
 
-        echo "export ANDROID_NDK_HOME=/opt/android/<< parameters.version >>" >> $BASH_ENV
+        if [[ -d "$HOME"/android-sdk/ndk/<< parameters.version >> ]]; then
+          android_ndk_home="$HOME/android-sdk/ndk/<< parameters.version >>" >> "$BASH_ENV"
 
-        if [[ -d $HOME/android-sdk/ndk/<< parameters.version >> ]] || [[ -d /opt/android/sdk/ndk/<< parameters.version >> ]]; then
-          echo "Android NDK installed"
+        elif [[ -d /opt/android/sdk/ndk/<< parameters.version >> ]]; then
+          android_ndk_home="/opt/android/<< parameters.version >>" >> "$BASH_ENV"
+
         else
           echo "Android NDK did not install successfully"
           exit 1
         fi
 
+        echo "export ANDROID_NDK_HOME=$android_ndk_home" >> "$BASH_ENV"
+        echo "Android NDK was installed at \"$android_ndk_home\"."

--- a/src/commands/install-ndk.yml
+++ b/src/commands/install-ndk.yml
@@ -26,10 +26,10 @@ steps:
         android_ndk_home=""
 
         if [[ -d "$HOME"/android-sdk/ndk/<< parameters.version >> ]]; then
-          android_ndk_home="$HOME/android-sdk/ndk/<< parameters.version >>" >> "$BASH_ENV"
+          android_ndk_home="$HOME/android-sdk/ndk/<< parameters.version >>"
 
         elif [[ -d /opt/android/sdk/ndk/<< parameters.version >> ]]; then
-          android_ndk_home="/opt/android/<< parameters.version >>" >> "$BASH_ENV"
+          android_ndk_home="/opt/android/<< parameters.version >>"
 
         else
           echo "Android NDK did not install successfully"


### PR DESCRIPTION

### Motivation, issues

This fix was drafted in response to the following issue: https://github.com/CircleCI-Public/android-orb/issues/39

### Description

Added conditional to install-ndk command so ANDROID_NDK_HOME will be set either with `$HOME/android-sdk/ndk/<< parameters.version >> ` or `/opt/android/sdk/ndk/<< parameters.version >>` with the default being the former