### PR TITLE
fix: added eval to find command

### DIFF
--- a/src/commands/restore-gradle-cache.yml
+++ b/src/commands/restore-gradle-cache.yml
@@ -10,7 +10,7 @@ parameters:
       Use this to customize how the find command is used to look for relevant
       file changes.
     type: string
-    default: . -type f \( -name 'build.gradle' -o -name 'settings.gradle' -o -name 'build.gradle.kts' -o -name 'settings.gradle.kts' \)
+    default: ". -name \"build.gradle*\" -o -name \"settings.gradle*\""
 steps:
   - run:
       environment:

--- a/src/commands/restore-gradle-cache.yml
+++ b/src/commands/restore-gradle-cache.yml
@@ -10,7 +10,7 @@ parameters:
       Use this to customize how the find command is used to look for relevant
       file changes.
     type: string
-    default: ". -name 'build.gradle' -name 'build.gradle.kts' -name 'settings.gradle' -name 'settings.gradle.kts'"
+    default: . -type f \( -name 'build.gradle' -o -name 'settings.gradle' -o -name 'build.gradle.kts' -o -name 'settings.gradle.kts' \)
 steps:
   - run:
       environment:

--- a/src/commands/restore-gradle-cache.yml
+++ b/src/commands/restore-gradle-cache.yml
@@ -10,7 +10,7 @@ parameters:
       Use this to customize how the find command is used to look for relevant
       file changes.
     type: string
-    default: ". -name 'build.gradle'"
+    default: ". -name 'build.gradle' -name 'build.gradle.kts' -name 'settings.gradle' -name 'settings.gradle.kts'"
 steps:
   - run:
       environment:

--- a/src/commands/start-emulator-and-run-tests.yml
+++ b/src/commands/start-emulator-and-run-tests.yml
@@ -119,7 +119,7 @@ parameters:
       Use this to customize how the find command is used to look for relevant
       file changes.
     type: string
-    default: ". -name 'build.gradle'"
+    default: . -type f \( -name 'build.gradle' -o -name 'settings.gradle' -o -name 'build.gradle.kts' -o -name 'settings.gradle.kts' \)
   save-gradle-cache:
     description: |
       Whether to write to the gradle cache after the tests have run

--- a/src/commands/start-emulator-and-run-tests.yml
+++ b/src/commands/start-emulator-and-run-tests.yml
@@ -119,7 +119,7 @@ parameters:
       Use this to customize how the find command is used to look for relevant
       file changes.
     type: string
-    default: . -type f \( -name 'build.gradle' -o -name 'settings.gradle' -o -name 'build.gradle.kts' -o -name 'settings.gradle.kts' \)
+    default: ". -name \"build.gradle*\" -o -name \"settings.gradle*\""
   save-gradle-cache:
     description: |
       Whether to write to the gradle cache after the tests have run

--- a/src/commands/start-emulator.yml
+++ b/src/commands/start-emulator.yml
@@ -102,7 +102,7 @@ parameters:
       Use this to customize how the find command is used to look for relevant
       file changes.
     type: string
-    default: ". -name 'build.gradle'"
+    default: . -type f \( -name 'build.gradle' -o -name 'settings.gradle' -o -name 'build.gradle.kts' -o -name 'settings.gradle.kts' \)
   post-emulator-wait-steps:
     description: |
       Steps to execute after waiting for the emulator to start up

--- a/src/commands/start-emulator.yml
+++ b/src/commands/start-emulator.yml
@@ -102,7 +102,7 @@ parameters:
       Use this to customize how the find command is used to look for relevant
       file changes.
     type: string
-    default: . -type f \( -name 'build.gradle' -o -name 'settings.gradle' -o -name 'build.gradle.kts' -o -name 'settings.gradle.kts' \)
+    default:  ". -name \"build.gradle*\" -o -name \"settings.gradle*\""
   post-emulator-wait-steps:
     description: |
       Steps to execute after waiting for the emulator to start up

--- a/src/jobs/run-ui-tests.yml
+++ b/src/jobs/run-ui-tests.yml
@@ -139,7 +139,7 @@ parameters:
       Use this to customize how the find command is used to look for relevant
       file changes.
     type: string
-    default: ". -name 'build.gradle'"
+    default: . -type f \( -name 'build.gradle' -o -name 'settings.gradle' -o -name 'build.gradle.kts' -o -name 'settings.gradle.kts' \)
   save-gradle-cache:
     description: |
       Whether to write to the gradle cache after the tests have run

--- a/src/jobs/run-ui-tests.yml
+++ b/src/jobs/run-ui-tests.yml
@@ -139,7 +139,7 @@ parameters:
       Use this to customize how the find command is used to look for relevant
       file changes.
     type: string
-    default: . -type f \( -name 'build.gradle' -o -name 'settings.gradle' -o -name 'build.gradle.kts' -o -name 'settings.gradle.kts' \)
+    default: ". -name \"build.gradle*\" -o -name \"settings.gradle*\""
   save-gradle-cache:
     description: |
       Whether to write to the gradle cache after the tests have run

--- a/src/scripts/generate-cache-checksum.sh
+++ b/src/scripts/generate-cache-checksum.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-find ${PARAM_FIND_ARGS} | sort | xargs cat |
-shasum | awk '{print $1}' > /tmp/gradle_cache_seed
+echo "The following are the files used to generate the cache checksum:"
+eval find "${PARAM_FIND_ARGS}"
+eval find "${PARAM_FIND_ARGS}" | sort | xargs cat |
+shasum | awk '{print $1}' > /tmp/gradle_cache_seed 


### PR DESCRIPTION
Added eval to the find command for `generate-cache-checksum` and reworded the default parameter for `PARAM_FIND_ARGS` to be easier to read. This should close [issue #49](https://github.com/CircleCI-Public/android-orb/issues/49)
