### PR TITLE
docs: Include link to Android machine tags list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ workflows:
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           # Use a context to hold your publishing token.
-          context: orb-publishing
+          context: orb-publisher
           filters: *filters
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   android: circleci/android@dev:<<pipeline.git.revision>>
   node: circleci/node@5.0.2
-  orb-tools: circleci/orb-tools@11.1
+  orb-tools: circleci/orb-tools@11.5.1
 
 filters: &filters
   tags:
@@ -45,7 +45,7 @@ jobs:
               exit 1
             fi
           name: check for correctness
-  
+
   test-ndk-install:
     parameters:
       executor:
@@ -149,15 +149,15 @@ jobs:
           post-emulator-launch-assemble-command: ""
           run-tests-working-directory: ./compose-samples/Jetchat
           post-run-tests-steps:
-            - android/save-build-cache  
+            - android/save-build-cache
 
-  test-fastlane: 
+  test-fastlane:
     docker:
       - image: cimg/android:2022.07
     resource_class: large
-    steps: 
+    steps:
       - checkout
-      - run: 
+      - run:
           name: clone sample project
           command: git clone git@github.com:CircleCI-Public/ReactNativeCFD.git
       - node/install:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -251,7 +251,7 @@ workflows:
           vcs-type: << pipeline.project.type >>
           pub-type: production
           requires: *prod-deploy-requires
-          context: orb-publishing
+          context: orb-publisher
           filters:
             branches:
               ignore: /.*/

--- a/src/executors/android-machine.yml
+++ b/src/executors/android-machine.yml
@@ -5,7 +5,7 @@ description: |
 parameters:
   tag:
     description: |
-      Name of CircleCI Android machine image to use. 
+      Name of CircleCI Android machine image to use.
       Android machine tags can be found at https://circleci.com/developer/machine/image/android#image-tags
     type: string
   resource-class:

--- a/src/executors/android-machine.yml
+++ b/src/executors/android-machine.yml
@@ -1,13 +1,12 @@
 description: |
   This selects an Android machine image.
   CircleCI's Android machine images are recommended for Android emulator tests.
-  Currently, this defaults to the first Android machine image, which is currently
-  in preview status: https://github.com/CircleCI-Public/android-image-preview-docs
 
 parameters:
   tag:
     description: |
-      Name of CircleCI Android machine image to use
+      Name of CircleCI Android machine image to use. 
+      Android machine tags can be found at https://circleci.com/developer/machine/image/android#image-tags
     type: string
   resource-class:
     description: |


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

The tag is required, and it was unclear where to find it.

### Description

Updated machine executor tag parameter description with dev hub link.
Also removed the reference to preview status archived repository
