### PR TITLE
added macOS support

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -62,6 +62,17 @@ jobs:
       - android/install-ndk:
           version: << parameters.ndk >>
 
+  test-sdk-install-macos:
+    parameters:
+      version:
+        type: string
+    macos:
+      xcode: 14.1.0
+    steps:
+      - checkout
+      - android/install-sdk-macos:
+          version: << parameters.version >>
+
   test-emulator-commands:
     parameters:
       system-image:
@@ -214,6 +225,16 @@ workflows:
                 - "23.0.7599858"
                 - "21.4.7075529"
                 - "19.2.5345600"
+          filters: *filters
+      - test-sdk-install-macos:
+          name: "Test SDK Install on macOS"
+          macos:
+            xcode: 14.1.0
+          matrix:
+            parameters:
+              version:
+                - "8512546"
+                - "9123335"
           filters: *filters
       - android/run-ui-tests:
           name: "ui-tests-<<matrix.system-image>>"

--- a/src/commands/install-sdk-macos.yml
+++ b/src/commands/install-sdk-macos.yml
@@ -1,0 +1,23 @@
+description: |
+  Install an Android SDK version for macOS. If the version is already
+  available, the step will still complete successfully.
+
+  This command is designed to be used with the CircleCI macOS.
+
+  Available SDK versions can be found here:
+  https://developer.android.com/studio#command-line-tools-only
+
+parameters:
+  version:
+    type: string
+    default: "9123335"
+    description: |
+      Version of the SDK to install. Available SDK versions can be found here:
+      https://developer.android.com/studio#command-line-tools-only
+
+steps:
+  - run:
+      environment:
+        PARAM_VER: << parameters.version >>
+      name: Install Android SDK
+      command: <<include(scripts/install-sdk-macos.sh)>>

--- a/src/examples/install-sdk-macos.yml
+++ b/src/examples/install-sdk-macos.yml
@@ -1,0 +1,19 @@
+description: |
+  A simple example of using the install-sdk-macos command
+  in a job, using most of the default parameters.
+usage:
+  version: 2.1
+  orbs:
+    android: circleci/android@2.0
+  jobs:
+    test:
+      macos:
+        xcode: 14.1.0
+      steps:
+        - checkout
+        # Install an Android SDK version for macOS. You can specify version if needed.
+        - android/install-sdk-macos
+  workflows:
+    test:
+      jobs:
+        - test

--- a/src/executors/macos.yml
+++ b/src/executors/macos.yml
@@ -1,0 +1,20 @@
+description: |
+  CircleCI's macOS execution environment:
+  https://circleci.com/docs/configuration-reference/#macos
+
+parameters:
+  xcode_version:
+    type: string
+    default: 14.1.0
+    description: |
+      Which macOS execution environment to use. For details, see
+      https://circleci.com/docs/configuration-reference/#macos
+  resource-class:
+    description: Resource class used for the executor.
+    type: enum
+    default: medium
+    enum: [medium, macos.x86.medium.gen2, large, macos.x86.metal.gen1]
+
+macos:
+  xcode: <<parameters.xcode_version>>
+resource_class: << parameters.resource-class >>

--- a/src/scripts/install-sdk-macos.sh
+++ b/src/scripts/install-sdk-macos.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+echo 'export ANDROID_SDK_ROOT=$HOME/android-sdk'  >> $BASH_ENV
+
+if [ -d $ANDROID_SDK_ROOT ]
+then
+    echo "Directory $ANDROID_SDK_ROOT already exists, so we're skipping the install."
+    exit 0
+fi
+
+mkdir -p $ANDROID_SDK_ROOT/cmdline-tools
+cd $ANDROID_SDK_ROOT/cmdline-tools
+
+curl https://dl.google.com/android/repository/commandlinetools-mac-${PARAM_VER}_latest.zip -o sdk-tools.zip
+unzip sdk-tools.zip
+rm sdk-tools.zip
+mv cmdline-tools latest
+
+SDKMANAGER=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager
+
+$SDKMANAGER "platform-tools"
+$SDKMANAGER "platforms;android-32"
+$SDKMANAGER "build-tools;32.0.0"
+
+echo 'export PATH=$ANDROID_SDK_ROOT/tools/bin:$PATH'  >> $BASH_ENV
+echo 'export PATH=$ANDROID_SDK_ROOT/tools:$PATH'  >> $BASH_ENV
+echo 'export PATH=$ANDROID_SDK_ROOT/platform-tools:$PATH'  >> $BASH_ENV
+echo 'export PATH=$ANDROID_SDK_ROOT/emulator:$PATH'  >> $BASH_ENV
+
+echo "Android SDK was installed at \"$ANDROID_SDK_ROOT\"."


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

macOS execution environment support is missing. It's very useful to be able to have Android SDK installed there when you're developing mobile app that uses Kotlin Multiplatform (https://kotlinlang.org/docs/multiplatform.html).

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Adds macOS execution environment support to be able to install Android SDK on it.