### PR TITLE
feat: added background to create-avd

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -85,7 +85,6 @@ jobs:
           avd-name: test1
           system-image: <<parameters.system-image>>
           install: true
-          background: true
       - android/start-emulator:
           avd-name: test1
           run-logcat: true
@@ -124,6 +123,12 @@ jobs:
                 command: |
                   echo "Test"
       - android/kill-emulators
+      - android/create-avd:
+          avd-name: test3
+          system-image: system-images;android-27;default;x86
+          install: true
+          background: true
+      - run: sleep 15 && echo "should cancel previous command"
 
   test-start-emulator-and-run-tests:
     parameters:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -85,6 +85,7 @@ jobs:
           avd-name: test1
           system-image: <<parameters.system-image>>
           install: true
+          background: true
       - android/start-emulator:
           avd-name: test1
           run-logcat: true
@@ -172,7 +173,7 @@ jobs:
           working-directory: ReactNativeCFD/android
       - android/fastlane-deploy:
           working-directory: ReactNativeCFD/android
-          lane-name: internal
+          lane-name: list
 
 workflows:
   test-deploy:

--- a/src/commands/create-avd.yml
+++ b/src/commands/create-avd.yml
@@ -25,18 +25,12 @@ parameters:
     description: |
       Additional args to be passed directly to the avd creation command
 steps:
-  - when:
-      condition: << parameters.install >>
-      steps:
-        - run:
-            name: Install system image "<< parameters.system-image >>"
-            command: |
-              sdkmanager "<< parameters.system-image >>"
-  - run:
-      environment:
-        PARAM_AVD_NAME: << parameters.avd-name >>
-        PARAM_SYSTEM_IMAGE: << parameters.system-image >>
-        PARAM_ADDITIONAL_ARGS: << parameters.additional-args >>
-      name: Create avd "<< parameters.avd-name >>"
-      command: <<include(scripts/create-avd.sh)>>
-      background: << parameters.background >>
+    - run:
+        environment:
+          PARAM_AVD_NAME: << parameters.avd-name >>
+          PARAM_INSTALL: << parameters.install >>
+          PARAM_SYSTEM_IMAGE: << parameters.system-image >>
+          PARAM_ADDITIONAL_ARGS: << parameters.additional-args >>
+        name: Create avd "<< parameters.avd-name >>"
+        command: <<include(scripts/create-avd.sh)>>
+        background: << parameters.background >>

--- a/src/commands/create-avd.yml
+++ b/src/commands/create-avd.yml
@@ -14,6 +14,11 @@ parameters:
     type: boolean
     description: |
       Whether to first install the system image via sdkmanager
+  background:
+    type: boolean
+    description: |
+      Where to run the creation command in background
+    default: false
   additional-args:
     type: string
     default: ""
@@ -34,3 +39,4 @@ steps:
         PARAM_ADDITIONAL_ARGS: << parameters.additional-args >>
       name: Create avd "<< parameters.avd-name >>"
       command: <<include(scripts/create-avd.sh)>>
+      background: << parameters.background >>

--- a/src/commands/create-avd.yml
+++ b/src/commands/create-avd.yml
@@ -17,7 +17,7 @@ parameters:
   background:
     type: boolean
     description: |
-      Where to run the creation command in background
+      Whether to run the creation command in background
     default: false
   additional-args:
     type: string

--- a/src/scripts/create-avd.sh
+++ b/src/scripts/create-avd.sh
@@ -1,2 +1,7 @@
 #!/bin/bash
+
+if [ "${PARAM_INSTALL}" == 1 ]; then
+    sdkmanager "${PARAM_SYSTEM_IMAGE}"
+fi
+
 echo "no" | avdmanager --verbose create avd -n ${PARAM_AVD_NAME} -k ${PARAM_SYSTEM_IMAGE} ${PARAM_ADDITIONAL_ARGS}


### PR DESCRIPTION
Added the ability to run create-avd in background, moved all run steps of `create-avd.yml `into the `create-avd.sh` file, and fixed the test-fastlane step of the `test-deploy` config. This should close [#63 ](https://github.com/CircleCI-Public/android-orb/issues/63)