### PR TITLE
feat: add pre-test command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -123,6 +123,12 @@ jobs:
                 command: |
                   echo "Test"
       - android/kill-emulators
+      - android/create-avd:
+          avd-name: test3
+          system-image: system-images;android-27;default;x86
+          install: true
+          background: true
+      - run: sleep 15 && echo "should cancel previous command"
 
   test-start-emulator-and-run-tests:
     parameters:
@@ -172,7 +178,7 @@ jobs:
           working-directory: ReactNativeCFD/android
       - android/fastlane-deploy:
           working-directory: ReactNativeCFD/android
-          lane-name: internal
+          lane-name: list
 
 workflows:
   test-deploy:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -93,6 +93,7 @@ jobs:
           post-emulator-launch-assemble-command: "cd compose-samples/Owl && ./gradlew assembleDebugAndroidTest && cd ../Jetsnack && ./gradlew assembleDebugAndroidTest"
       - android/run-tests:
           working-directory: ./compose-samples/Owl
+          pre-test-command: "./gradlew clean"
       - android/run-tests:
           working-directory: ./compose-samples/Jetsnack
       - android/save-gradle-cache:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# Automatically request PR reviews from the CPE Team as a whole and the Images subteam
-*	@CircleCI-Public/cpeng @CircleCI-Public/images
+*	@CircleCI-Public/images

--- a/src/commands/create-avd.yml
+++ b/src/commands/create-avd.yml
@@ -14,23 +14,23 @@ parameters:
     type: boolean
     description: |
       Whether to first install the system image via sdkmanager
+  background:
+    type: boolean
+    description: |
+      Whether to run the creation command in background
+    default: false
   additional-args:
     type: string
     default: ""
     description: |
       Additional args to be passed directly to the avd creation command
 steps:
-  - when:
-      condition: << parameters.install >>
-      steps:
-        - run:
-            name: Install system image "<< parameters.system-image >>"
-            command: |
-              sdkmanager "<< parameters.system-image >>"
-  - run:
-      environment:
-        PARAM_AVD_NAME: << parameters.avd-name >>
-        PARAM_SYSTEM_IMAGE: << parameters.system-image >>
-        PARAM_ADDITIONAL_ARGS: << parameters.additional-args >>
-      name: Create avd "<< parameters.avd-name >>"
-      command: <<include(scripts/create-avd.sh)>>
+    - run:
+        environment:
+          PARAM_AVD_NAME: << parameters.avd-name >>
+          PARAM_INSTALL: << parameters.install >>
+          PARAM_SYSTEM_IMAGE: << parameters.system-image >>
+          PARAM_ADDITIONAL_ARGS: << parameters.additional-args >>
+        name: Create avd "<< parameters.avd-name >>"
+        command: <<include(scripts/create-avd.sh)>>
+        background: << parameters.background >>

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -5,6 +5,10 @@ parameters:
     description: Command to run in order to run the tests
     type: string
     default: "./gradlew connectedDebugAndroidTest"
+  pre-test-command:
+    description: Command to run prior to runnning the test command
+    type: string
+    default: " "
   working-directory:
     description: Working directory to run the tests in
     type: string
@@ -26,6 +30,7 @@ steps:
       environment:
         PARAM_MAX_TRIES: << parameters.max-tries >>
         PARAM_TEST_COMMAND: << parameters.test-command >>
+        PARAM_PRE_TEST_COMMAND: << parameters.pre-test-command >>
         PARAM_RETRY_INTERVAL: << parameters.retry-interval >>
       name: Run tests with max tries of <<parameters.max-tries>>
       working_directory: <<parameters.working-directory>>

--- a/src/commands/start-emulator-and-run-tests.yml
+++ b/src/commands/start-emulator-and-run-tests.yml
@@ -155,6 +155,10 @@ parameters:
       Steps to run after the tests
     type: steps
     default: []
+  pre-test-command:
+    description: Command to run prior to runnning the test command
+    type: string
+    default: " "
   test-command:
     description: Command to run in order to run the tests
     type: string
@@ -214,6 +218,7 @@ steps:
   - << parameters.pre-run-tests-steps >>
   - run-tests:
       working-directory: << parameters.run-tests-working-directory >>
+      pre-test-command: << parameters.pre-test-command >>
       test-command: << parameters.test-command >>
       max-tries: << parameters.max-tries >>
       retry-interval: << parameters.retry-interval >>

--- a/src/jobs/run-ui-tests.yml
+++ b/src/jobs/run-ui-tests.yml
@@ -2,6 +2,10 @@ description: |
   Creates an AVD, starts an emulator and runs Android UI tests.
   This is a job that wraps the "start-emulator-and-run-tests" command.
 parameters:
+  pre-test-command:
+    description: Command to run prior to runnning the test command
+    type: string
+    default: " "
   test-command:
     description: Command to run in order to run the tests
     type: string
@@ -223,6 +227,7 @@ steps:
       pre-run-tests-steps: << parameters.pre-run-tests-steps >>
       post-run-tests-steps: << parameters.post-run-tests-steps >>
       run-tests-working-directory: << parameters.run-tests-working-directory >>
+      pre-test-command: << parameters.pre-test-command >>
       test-command: << parameters.test-command >>
       max-tries: << parameters.max-tries >>
       retry-interval: << parameters.retry-interval >>

--- a/src/scripts/create-avd.sh
+++ b/src/scripts/create-avd.sh
@@ -1,2 +1,7 @@
 #!/bin/bash
+
+if [ "${PARAM_INSTALL}" == 1 ]; then
+    sdkmanager "${PARAM_SYSTEM_IMAGE}"
+fi
+
 echo "no" | avdmanager --verbose create avd -n ${PARAM_AVD_NAME} -k ${PARAM_SYSTEM_IMAGE} ${PARAM_ADDITIONAL_ARGS}

--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -5,6 +5,7 @@ run_with_retry() {
             until [ $n -gt $MAX_TRIES ]
             do
               echo "Starting test attempt $n"
+              ${PARAM_PRE_TEST_COMMAND}
               ${PARAM_TEST_COMMAND} && break
               n=$((n+1))
               sleep "${PARAM_RETRY_INTERVAL}"


### PR DESCRIPTION
This PR should close [#57](https://github.com/CircleCI-Public/android-orb/issues/57) by adding a parameter to `run-tests` that allows users to run a command before their test command
