### PR TITLE
feat: add pre test command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -93,7 +93,7 @@ jobs:
           post-emulator-launch-assemble-command: "cd compose-samples/Owl && ./gradlew assembleDebugAndroidTest && cd ../Jetsnack && ./gradlew assembleDebugAndroidTest"
       - android/run-tests:
           working-directory: ./compose-samples/Owl
-          pre-test-command: "./gradlew clean && echo 'beginning tests"
+          pre-test-command: "./gradlew tasks"
       - android/run-tests:
           working-directory: ./compose-samples/Jetsnack
       - android/save-gradle-cache:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -93,6 +93,7 @@ jobs:
           post-emulator-launch-assemble-command: "cd compose-samples/Owl && ./gradlew assembleDebugAndroidTest && cd ../Jetsnack && ./gradlew assembleDebugAndroidTest"
       - android/run-tests:
           working-directory: ./compose-samples/Owl
+          pre-test-command: "./gradlew clean && echo 'beginning tests"
       - android/run-tests:
           working-directory: ./compose-samples/Jetsnack
       - android/save-gradle-cache:

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -1,6 +1,10 @@
 description: |
   Runs tests, with retries supported
 parameters:
+  pre-test-command:
+    description: Command to run prior to runnning the test command
+    type: string
+    default: " "
   test-command:
     description: Command to run in order to run the tests
     type: string
@@ -26,6 +30,7 @@ steps:
       environment:
         PARAM_MAX_TRIES: << parameters.max-tries >>
         PARAM_TEST_COMMAND: << parameters.test-command >>
+        PARAM_PRE_TEST_COMMAND: << parameters.pre-test-command >>
         PARAM_RETRY_INTERVAL: << parameters.retry-interval >>
       name: Run tests with max tries of <<parameters.max-tries>>
       working_directory: <<parameters.working-directory>>

--- a/src/commands/start-emulator-and-run-tests.yml
+++ b/src/commands/start-emulator-and-run-tests.yml
@@ -155,6 +155,10 @@ parameters:
       Steps to run after the tests
     type: steps
     default: []
+  pre-test-command:
+    description: Command to run prior to runnning the test command
+    type: string
+    default: " "
   test-command:
     description: Command to run in order to run the tests
     type: string
@@ -214,6 +218,7 @@ steps:
   - << parameters.pre-run-tests-steps >>
   - run-tests:
       working-directory: << parameters.run-tests-working-directory >>
+      pre-test-command: << parameters.pre-test-command >>
       test-command: << parameters.test-command >>
       max-tries: << parameters.max-tries >>
       retry-interval: << parameters.retry-interval >>

--- a/src/jobs/run-ui-tests.yml
+++ b/src/jobs/run-ui-tests.yml
@@ -2,6 +2,10 @@ description: |
   Creates an AVD, starts an emulator and runs Android UI tests.
   This is a job that wraps the "start-emulator-and-run-tests" command.
 parameters:
+  pre-test-command:
+    description: Command to run prior to runnning the test command
+    type: string
+    default: " "
   test-command:
     description: Command to run in order to run the tests
     type: string
@@ -223,6 +227,7 @@ steps:
       pre-run-tests-steps: << parameters.pre-run-tests-steps >>
       post-run-tests-steps: << parameters.post-run-tests-steps >>
       run-tests-working-directory: << parameters.run-tests-working-directory >>
+      pre-test-command: << parameters.pre-test-command >>
       test-command: << parameters.test-command >>
       max-tries: << parameters.max-tries >>
       retry-interval: << parameters.retry-interval >>

--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -5,6 +5,7 @@ run_with_retry() {
             until [ $n -gt $MAX_TRIES ]
             do
               echo "Starting test attempt $n"
+              ${PARAM_PRE_TEST_COMMAND}
               ${PARAM_TEST_COMMAND} && break
               n=$((n+1))
               sleep "${PARAM_RETRY_INTERVAL}"


### PR DESCRIPTION
This PR should close [#57](https://github.com/CircleCI-Public/android-orb/issues/57) by adding a parameter to `run-tests` that allows users to run a command before their test command
