### PR TITLE
feat: add adp pull parameter

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -157,6 +157,8 @@ jobs:
           run-tests-working-directory: ./compose-samples/Jetchat
           post-run-tests-steps:
             - android/save-build-cache
+          pull-data: true
+          pull-data-path: storage
 
   test-fastlane:
     docker:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -159,6 +159,7 @@ jobs:
             - android/save-build-cache
           pull-data: true
           pull-data-path: storage
+          pull-data-target: "."
 
   test-fastlane:
     docker:

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -25,6 +25,21 @@ parameters:
     description: Use this to configure the no_output_timeout value
     type: string
     default: 10m
+  pull-data:
+    description: |
+      Whether to pull data after running tests
+    type: boolean
+    default: false
+  pull-data-path:
+    description: |
+      Emulator directory to pull data from
+    type: string
+    default: data
+  pull-data-target:
+    description: |
+      Location to save pulled data
+    type: string
+    default: .
 steps:
   - run:
       environment:
@@ -35,3 +50,7 @@ steps:
       name: Run tests with max tries of <<parameters.max-tries>>
       working_directory: <<parameters.working-directory>>
       command: <<include(scripts/run-tests.sh)>>
+  - when:
+      condition: << parameters.pull-data >>
+      steps:
+        - run: adb pull << parameters.pull-data-path >> << pull-data-target >>

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -39,7 +39,7 @@ parameters:
     description: |
       Location to save pulled data
     type: string
-    default: .
+    default: "."
 steps:
   - run:
       environment:
@@ -53,4 +53,4 @@ steps:
   - when:
       condition: << parameters.pull-data >>
       steps:
-        - run: adb pull << parameters.pull-data-path >> << pull-data-target >>
+        - run: adb pull << parameters.pull-data-path >> << parameters.pull-data-target >>

--- a/src/commands/start-emulator-and-run-tests.yml
+++ b/src/commands/start-emulator-and-run-tests.yml
@@ -185,6 +185,21 @@ parameters:
       Whether to kill the emulators after the tests complete
     type: boolean
     default: true
+  pull-data:
+    description: |
+      Whether to pull data after running tests
+    type: boolean
+    default: false
+  pull-data-path:
+    description: |
+      Emulator directory to pull data from
+    type: string
+    default: data
+  pull-data-target:
+    description: |
+      Location to save pulled data
+    type: string
+    default: .
 
 steps:
   - create-avd:
@@ -223,6 +238,9 @@ steps:
       max-tries: << parameters.max-tries >>
       retry-interval: << parameters.retry-interval >>
       no-output-timeout: << parameters.no-output-timeout >>
+      pull-data: << parameters.pull-data >>
+      pull-data-path: << parameters.pull-data-path >>
+      pull-data-target: << parameters.pull-data-target >>
   - << parameters.post-run-tests-steps >>
   - when:
       condition: << parameters.save-gradle-cache >>

--- a/src/commands/start-emulator-and-run-tests.yml
+++ b/src/commands/start-emulator-and-run-tests.yml
@@ -199,7 +199,7 @@ parameters:
     description: |
       Location to save pulled data
     type: string
-    default: .
+    default: "."
 
 steps:
   - create-avd:

--- a/src/jobs/run-ui-tests.yml
+++ b/src/jobs/run-ui-tests.yml
@@ -191,6 +191,22 @@ parameters:
       Whether to kill the emulators after the tests complete
     type: boolean
     default: true
+  pull-data:
+    description: |
+      Whether to pull data after running tests
+    type: boolean
+    default: false
+  pull-data-path:
+    description: |
+      Emulator directory to pull data from
+    type: string
+    default: data
+  pull-data-target:
+    description: |
+      Location to save pulled data
+    type: string
+    default: "."
+
 executor: << parameters.executor >>
 steps:
   - when:
@@ -233,3 +249,6 @@ steps:
       retry-interval: << parameters.retry-interval >>
       no-output-timeout: << parameters.no-output-timeout >>
       kill-emulators: << parameters.kill-emulators >>
+      pull-data: << parameters.pull-data >>
+      pull-data-path: << parameters.pull-data-path >>
+      pull-data-target: << parameters.pull-data-target >>


### PR DESCRIPTION
this should close #55 , adds a parameter to the `run-ui-tests` job, `start-emulator-and-run-tests` command and the `run-tests` command for running `adb pull` after your test run.