### PR TITLE
fix: change java version command to handle java 17 being installed instead of 11

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -40,8 +40,14 @@ jobs:
           command: |
             JAVA_VER="$( java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 )"
             JAVAC_VER="$( javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1 )"
-            if [ "$JAVA_VER" -ne <<parameters.java-version>> ] || [ "$JAVAC_VER" -ne <<parameters.java-version>> ]; then
-              echo "Job failed because either the java version or javac version was not changed."
+            if [ "$JAVA_VER" -ne <<parameters.java-version>> ]; then
+              echo "Job failed because java version was not changed."
+              echo "current java version:" $JAVA_VER
+              exit 1
+            fi
+            if [ "$JAVAC_VER" -ne <<parameters.java-version>> ]; then
+              echo "Job failed because javac version was not changed."
+              echo "current javac version:" $JAVAC_VER
               exit 1
             fi
           name: check for correctness
@@ -191,13 +197,14 @@ workflows:
           name: "Test OpenJDK version change"
           executor:
             name: android/android-docker
-            tag: "2021.10.1"
+            tag: "2023.03.1"
           matrix:
             parameters:
               java-version:
                 - 8
                 - 11
-                - 13
+                - 17
+                - 18
           filters: *filters
       - test-ndk-install:
           name: "Test NDK Install on Android Docker"

--- a/src/commands/change-java-version.yml
+++ b/src/commands/change-java-version.yml
@@ -1,5 +1,5 @@
 description: |
-  Change default java version from OpenJDK v11.
+  Change default java version from OpenJDK v17.
 parameters:
   java-version:
     type: integer
@@ -10,5 +10,5 @@ steps:
   - run:
       environment:
         PARAM_JAVA_VER: << parameters.java-version >>
-      name: Change OpenJDK version
+      name: Change OpenJDK version to << parameters.java-version >>
       command: <<include(scripts/change-java-version.sh)>>

--- a/src/scripts/change-java-version.sh
+++ b/src/scripts/change-java-version.sh
@@ -4,18 +4,20 @@
         echo "Current Java Version: $CURRENT_JAVA_VER"
         echo "Current Java Compiler Version : $CURRENT_JAVAC_VER"
         if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ]; then
-          if [ "${PARAM_JAVA_VER}" -eq 8 ] || [ "${PARAM_JAVA_VER}" -eq 11 ]; then
+          if [ "${PARAM_JAVA_VER}" -eq 8 ] || [ "${PARAM_JAVA_VER}" -eq 17 ]; then
             if [ "${PARAM_JAVA_VER}" -eq 8 ]; then
               sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
             else
-              sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+              sudo update-alternatives --set java /usr/lib/jvm/java-17-openjdk-amd64/bin/java
             fi
             sudo update-alternatives --set javac /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-openjdk-amd64/bin/javac
           else
             sudo apt install openjdk-"${PARAM_JAVA_VER}"-jdk
+            sudo update-alternatives --set javac /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-openjdk-amd64/bin/javac
+            sudo update-alternatives --set java /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-openjdk-amd64/bin/java
           fi
-          echo "export JAVA_HOME=/usr/lib/jvm/java-${PARAM_JAVA_VER}-openjdk-amd64" >>~/.bashrc
-          echo "export PATH=$JAVA_HOME/bin:$PATH" >>~/.bashrc
+          echo "export JAVA_HOME=/usr/lib/jvm/java-${PARAM_JAVA_VER}-openjdk-amd64" >> ~/.bashrc
+          echo "export PATH=$JAVA_HOME/bin:$PATH" >> ~/.bashrc
         fi
         NEW_JAVA_VER="$( java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 )"
         NEW_JAVAC_VER="$( javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1 )"


### PR DESCRIPTION
This PR does the following changes:
* Upgrades the test image for the `test-java-version` to the new `android:2023.03.1` docker image
* Widens the net for testing this command, now tests for 8, 11, 17 and 18 to test for both installed versions, one older than the current, and one newer
* Improves the name for the `change_java_version` command
* Fixes an issue with installing an older version of java than the current