### PR TITLE
fix: passed env var correctly to create play key

### DIFF
--- a/src/commands/create-google-play-key.yml
+++ b/src/commands/create-google-play-key.yml
@@ -12,5 +12,5 @@ parameters:
 steps:
   - run:
       name: Create Google Play key
-      command: echo << parameters.google-play-key >> > google-play-key.json
+      command: echo ${<< parameters.google-play-key >>} > google-play-key.json
       working_directory: << parameters.working-directory >>


### PR DESCRIPTION
This should close #75 and allow for the `deploy-to-play-store` job to be used as intended