### PR TITLE
fix: fix java installs

### DIFF
--- a/src/scripts/change-java-version.sh
+++ b/src/scripts/change-java-version.sh
@@ -12,6 +12,7 @@
             fi
             sudo update-alternatives --set javac /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-openjdk-amd64/bin/javac
           else
+            sudo apt-get update
             sudo apt install openjdk-"${PARAM_JAVA_VER}"-jdk
             sudo update-alternatives --set javac /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-openjdk-amd64/bin/javac
             sudo update-alternatives --set java /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-openjdk-amd64/bin/java


### PR DESCRIPTION
The Java 11 test had been failing for `change-java-version` so I went in and added sudo apt-get update before the install to alleviate this issue.