### PR TITLE
Fix/boolean check

### DIFF
--- a/src/scripts/change-malloc-implementation.sh
+++ b/src/scripts/change-malloc-implementation.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+sudo apt update
+
 if [[ ${PARAM_IMPLEMENTATION} == "jemalloc" ]]; then
     sudo apt install libjemalloc-dev
     echo "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2" | sudo tee -a /etc/environment

--- a/src/scripts/start-emulator.sh
+++ b/src/scripts/start-emulator.sh
@@ -1,38 +1,38 @@
 #!/bin/bash
 if [ -n "${PARAM_OVERRIDE_ARGS}" ]; then
-          echo "override-args parameter was supplied; orb defaults will be overridden"
-          emulator -avd ${PARAM_AVD_NAME} ${PARAM_OVERRIDE_ARGS}
-        else
-          if [ "${PARAM_NO_WINDOW}" == "true" ]; then
-            set -- "$@" -no-window
-          fi
-          if [ "${PARAM_NO_AUDIO}" == "true" ]; then
-            set -- "$@" -no-audio
-          fi
-          if [ "${PARAM_NO_BOOT_ANIM}" == "true" ]; then
-            set -- "$@" -no-boot-anim
-          fi
-          if [ "${PARAM_VERBOSE}" == "true" ]; then
-            set -- "$@" -verbose
-          fi
-          if [ "${PARAM_NO_SNAPSHOT}" == "true" ]; then
-            set -- "$@" -no-snapshot
-          fi
-          if [ "${PARAM_DELAY_ABD}" == "true" ]; then
-            set -- "$@" -delay-adb
-          fi
-          if [ "${PARAM_MEMORY}" != "-1" ]; then
-            set -- "$@" -memory ${PARAM_MEMORY}
-          fi
-          if [ -n "${PARAM_GPU}" ]; then
-            set -- "$@" -gpu "${PARAM_GPU}"
-          fi
-          if [ -n "${PARAM_CAMERA_FRONT}" ]; then
-            set -- "$@" -camera-front "${PARAM_CAMERA_FRONT}"
-          fi
-          if [ -n "${PARAM_CAMERA_BACK}" ]; then
-            set -- "$@" -camera-back "${PARAM_CAMERA_BACK}"
-          fi
-          echo "Starting emulator with arguments $* ${PARAM_ADDITIONAL_ARGS}"
-          emulator -avd ${PARAM_AVD_NAME} "$@" ${PARAM_ADDITIONAL_ARGS}
-        fi
+  echo "override-args parameter was supplied; orb defaults will be overridden"
+  emulator -avd ${PARAM_AVD_NAME} ${PARAM_OVERRIDE_ARGS}
+else
+  if [ "${PARAM_NO_WINDOW}" -eq 1 ]; then
+    set -- "$@" -no-window
+  fi
+  if [ "${PARAM_NO_AUDIO}" -eq 1 ]; then
+    set -- "$@" -no-audio
+  fi
+  if [ "${PARAM_NO_BOOT_ANIM}" -eq 1 ]; then
+    set -- "$@" -no-boot-anim
+  fi
+  if [ "${PARAM_VERBOSE}" -eq 1 ]; then
+    set -- "$@" -verbose
+  fi
+  if [ "${PARAM_NO_SNAPSHOT}" -eq 1 ]; then
+    set -- "$@" -no-snapshot
+  fi
+  if [ "${PARAM_DELAY_ABD}" -eq 1 ]; then
+    set -- "$@" -delay-adb
+  fi
+  if [ "${PARAM_MEMORY}" != "-1" ]; then
+    set -- "$@" -memory ${PARAM_MEMORY}
+  fi
+  if [ -n "${PARAM_GPU}" ]; then
+    set -- "$@" -gpu "${PARAM_GPU}"
+  fi
+  if [ -n "${PARAM_CAMERA_FRONT}" ]; then
+    set -- "$@" -camera-front "${PARAM_CAMERA_FRONT}"
+  fi
+  if [ -n "${PARAM_CAMERA_BACK}" ]; then
+    set -- "$@" -camera-back "${PARAM_CAMERA_BACK}"
+  fi
+  echo "Starting emulator with arguments $* ${PARAM_ADDITIONAL_ARGS}"
+  emulator -avd ${PARAM_AVD_NAME} "$@" ${PARAM_ADDITIONAL_ARGS}
+fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

This PR fixes several flags that ship with the `start-emulator` command. We were checking the flag's existence with `true` and `false` instead of `1s` and `0s`. 
