### PR TITLE
Add executor to job

### DIFF
--- a/src/examples/run-ui-tests-job.yml
+++ b/src/examples/run-ui-tests-job.yml
@@ -14,3 +14,7 @@ usage:
             # Specify job "pre-steps" and "post-steps" if necessary
             # to execute custom steps before and afer any of the built-in steps
             system-image: "system-images;android-28;default;x86"
+            executor:
+              name: android/android-machine
+              resource-class: large
+              tag: 2021.10.1

--- a/src/examples/run-ui-tests-job.yml
+++ b/src/examples/run-ui-tests-job.yml
@@ -17,4 +17,4 @@ usage:
             executor:
               name: android/android-machine
               resource-class: large
-              tag: 2021.10.1
+              tag: 2024.01.1


### PR DESCRIPTION
The executor is required, but was missing from the example