### PR TITLE
Update CODEOWNERS to use orb-publishers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@CircleCI-Public/images
+*	@CircleCI-Public/orb-publishers


### PR DESCRIPTION
Updates the CODEOWNERS file to use the orb-publishers team like the rest of our orbs.
