### PR TITLE
Update context to use in publish

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -281,7 +281,7 @@ workflows:
           vcs_type: << pipeline.project.type >>
           pub_type: production
           requires: *prod-deploy-requires
-          context: image-orbs
+          context: orb-publisher
           filters:
             branches:
               ignore: /.*/

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -4,4 +4,3 @@ description: |
 display:
   source_url: https://github.com/circleci-public/android-orb
 version: 2.1
-

--- a/src/commands/create_avd.yml
+++ b/src/commands/create_avd.yml
@@ -4,12 +4,14 @@ parameters:
   avd_name:
     type: string
     description: |
-      The name of the AVD to create
+      The name of the AVD to create.
+      You can pass environment variables, using the $ syntax e.g. "$AVD_NAME"
   system_image:
     type: string
     description: |
       Name of system image e.g. "system-images;android-29;default;x86".
       It should match the name seen in the "sdkmanager --list" output.
+     You can pass environment variables, using the $ syntax e.g. "$SYSTEM_IMAGE"
   install:
     type: boolean
     description: |
@@ -24,6 +26,7 @@ parameters:
     default: ""
     description: |
       Additional args to be passed directly to the avd creation command
+      You can pass environment variables, using the $ syntax e.g. "$ADDITIONAL_ARGS"
 steps:
     - run:
         environment:

--- a/src/commands/create_avd.yml
+++ b/src/commands/create_avd.yml
@@ -11,7 +11,7 @@ parameters:
     description: |
       Name of system image e.g. "system-images;android-29;default;x86".
       It should match the name seen in the "sdkmanager --list" output.
-     You can pass environment variables, using the $ syntax e.g. "$SYSTEM_IMAGE"
+      You can pass environment variables, using the $ syntax e.g. "$SYSTEM_IMAGE"
   install:
     type: boolean
     description: |
@@ -28,12 +28,12 @@ parameters:
       Additional args to be passed directly to the avd creation command
       You can pass environment variables, using the $ syntax e.g. "$ADDITIONAL_ARGS"
 steps:
-    - run:
-        environment:
-          PARAM_AVD_NAME: << parameters.avd_name >>
-          PARAM_INSTALL: << parameters.install >>
-          PARAM_SYSTEM_IMAGE: << parameters.system_image >>
-          PARAM_ADDITIONAL_ARGS: << parameters.additional_args >>
-        name: Create avd "<< parameters.avd_name >>"
-        command: <<include(scripts/create_avd.sh)>>
-        background: << parameters.background >>
+  - run:
+      environment:
+        PARAM_AVD_NAME: << parameters.avd_name >>
+        PARAM_INSTALL: << parameters.install >>
+        PARAM_SYSTEM_IMAGE: << parameters.system_image >>
+        PARAM_ADDITIONAL_ARGS: << parameters.additional_args >>
+      name: Create avd "<< parameters.avd_name >>"
+      command: <<include(scripts/create_avd.sh)>>
+      background: << parameters.background >>

--- a/src/commands/run_tests.yml
+++ b/src/commands/run_tests.yml
@@ -2,11 +2,15 @@ description: |
   Runs tests, with retries supported
 parameters:
   pre_test_command:
-    description: Command to run prior to runnning the test command
+    description: |
+      Command to run prior to runnning the test command
+      You can pass environment variables, using the $ syntax e.g. "$PRE_TEST_COMMAND"
     type: string
     default: " "
   test_command:
-    description: Command to run in order to run the tests
+    description: |
+      Command to run in order to run the tests
+      You can pass environment variables, using the $ syntax e.g. "$TEST_COMMAND"
     type: string
     default: "./gradlew connectedDebugAndroidTest"
   working_directory:

--- a/src/commands/start_emulator.yml
+++ b/src/commands/start_emulator.yml
@@ -102,7 +102,7 @@ parameters:
       Use this to customize how the find command is used to look for relevant
       file changes.
     type: string
-    default:  ". -name \"build.gradle*\" -o -name \"settings.gradle*\""
+    default: ". -name \"build.gradle*\" -o -name \"settings.gradle*\""
   post_emulator_wait_steps:
     description: |
       Steps to execute after waiting for the emulator to start up
@@ -182,5 +182,5 @@ steps:
         - when:
             condition: << parameters.disable_animations >>
             steps:
-                - disable_animations
+              - disable_animations
         - << parameters.post_emulator_wait_steps >>

--- a/src/commands/start_emulator_and_run_tests.yml
+++ b/src/commands/start_emulator_and_run_tests.yml
@@ -5,13 +5,15 @@ description: |
 parameters:
   avd_name:
     description: |
-      The name of the AVD to create
+      The name of the AVD to create.
+      You can pass environment variables, using the $ syntax e.g. "$AVD_NAME"
     type: string
     default: test
   system_image:
     description: |
       Name of system image e.g. "system-images;android-29;default;x86".
       It should match the name seen in the "sdkmanager --list" output.
+      You can pass environment variables, using the $ syntax e.g. "$SYSTEM_IMAGE"
     type: string
     default: system-images;android-29;default;x86
   install_system_image:
@@ -21,7 +23,8 @@ parameters:
     default: true
   additional_avd_args:
     description: |
-      Additional args to be passed directly to the avd creation command
+      Additional args to be passed directly to the avd creation command.
+      You can pass environment variables, using the $ syntax e.g. "$ADDITIONAL_ARGS"
     type: string
     default: ""
   gpu:
@@ -156,11 +159,15 @@ parameters:
     type: steps
     default: []
   pre_test_command:
-    description: Command to run prior to runnning the test command
+    description: |
+      Command to run prior to runnning the test command
+      You can pass environment variables, using the $ syntax e.g. "$PRE_TEST_COMMAND"
     type: string
     default: " "
   test_command:
-    description: Command to run in order to run the tests
+    description: |
+      Command to run in order to run the tests
+      You can pass environment variables, using the $ syntax e.g. "$TEST_COMMAND"
     type: string
     default: "./gradlew connectedDebugAndroidTest"
   run_tests_working_directory:

--- a/src/examples/test_matrix.yml
+++ b/src/examples/test_matrix.yml
@@ -13,4 +13,3 @@ usage:
             matrix:
               parameters:
                 system_image: ["system-images;android-31;default;x86_64", "system-images;android-31;default;x86_64"]
-

--- a/src/jobs/deploy_to_play_store.yml
+++ b/src/jobs/deploy_to_play_store.yml
@@ -71,4 +71,3 @@ steps:
   - fastlane_deploy:
       lane_name: << parameters.lane_name >>
       working_directory: << parameters.fastlane_working_directory >>
-

--- a/src/scripts/create_avd.sh
+++ b/src/scripts/create_avd.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+PARAM_AVD_NAME="$(circleci env subst "$PARAM_AVD_NAME")"
+PARAM_SYSTEM_IMAGE="$(circleci env subst "$PARAM_SYSTEM_IMAGE")"
+PARAM_ADDITIONAL_ARGS="$(circleci env subst "$PARAM_ADDITIONAL_ARGS")"
 
 if [ "${PARAM_INSTALL}" == 1 ]; then
     sdkmanager "${PARAM_SYSTEM_IMAGE}"

--- a/src/scripts/install_ndk.sh
+++ b/src/scripts/install_ndk.sh
@@ -4,7 +4,7 @@ android_ndk_home=""
   if [[ -d "${HOME}/android-sdk/ndk/${PARAM_VER}" ]]; then
     android_ndk_home="$HOME/android-sdk/ndk/${PARAM_VER}"
   elif [[ -d "/opt/android/sdk/ndk/${PARAM_VER}" ]]; then
-    android_ndk_home="/opt/android/${PARAM_VER}"
+    android_ndk_home="/opt/android/sdk/ndk/${PARAM_VER}"
   else
     echo "Android NDK did not install successfully"
     exit 1

--- a/src/scripts/run_tests.sh
+++ b/src/scripts/run_tests.sh
@@ -1,18 +1,20 @@
 #!/bin/bash
+PARAM_PRE_TEST_COMMAND="$(circleci env subst "$PARAM_PRE_TEST_COMMAND")"
+PARAM_TEST_COMMAND="$(circleci env subst "$PARAM_TEST_COMMAND")"
+
 run_with_retry() {
-            MAX_TRIES=${PARAM_MAX_TRIES}
-            n=1
-            until [ $n -gt $MAX_TRIES ]
-            do
-              echo "Starting test attempt $n"
-              ${PARAM_PRE_TEST_COMMAND}
-              ${PARAM_TEST_COMMAND} && break
-              n=$((n+1))
-              sleep "${PARAM_RETRY_INTERVAL}"
-            done
-            if [ $n -gt $MAX_TRIES ]; then
-              echo "Max tries reached (${PARAM_MAX_TRIES})"
-              exit 1
-            fi
-        }
-        run_with_retry
+  MAX_TRIES=${PARAM_MAX_TRIES}
+  n=1
+  until [ $n -gt $MAX_TRIES ]; do
+    echo "Starting test attempt $n"
+    ${PARAM_PRE_TEST_COMMAND}
+    ${PARAM_TEST_COMMAND} && break
+    n=$((n + 1))
+    sleep "${PARAM_RETRY_INTERVAL}"
+  done
+  if [ $n -gt $MAX_TRIES ]; then
+    echo "Max tries reached (${PARAM_MAX_TRIES})"
+    exit 1
+  fi
+}
+run_with_retry


### PR DESCRIPTION
I'm updating the context to use in the publish step to avoid issues with the old context used.

I'm also adding the possibility to pass some of the parameters as environment variables, this was possible in version 2.1.0 and previous, based on issue #56.

I'm also fixing the android_ndk_home path, based on issue #91.