### PR TITLE
Fix issue when replacing arguments with circleci env subst

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -134,9 +134,13 @@ jobs:
         type: string
         default: ""
         description: Additional args to pass to avd creation
+      shell:
+        type: string
+        default: "bash -eo pipefail"
     executor:
       name: android/android_machine
       tag: << parameters.tag >>
+      shell: <<parameters.shell>>
       resource_class: xlarge
     steps:
       - checkout
@@ -283,7 +287,7 @@ workflows:
       - test_start_emulator_and_run_tests:
           name: test_start_emulator_and_run_tests-with-args
           tag: "default"
-          shell: bash -eox pipefail
+          shell: "bash -eox pipefail"
           args: -d pixel_6
           filters: *filters
       - test-fastlane

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -134,13 +134,9 @@ jobs:
         type: string
         default: ""
         description: Additional args to pass to avd creation
-      shell:
-        type: string
-        default: "bash -eo pipefail"
     executor:
       name: android/android_machine
       tag: << parameters.tag >>
-      shell: <<parameters.shell>>
       resource_class: xlarge
     steps:
       - checkout
@@ -287,7 +283,6 @@ workflows:
       - test_start_emulator_and_run_tests:
           name: test_start_emulator_and_run_tests-with-args
           tag: "default"
-          shell: "bash -eox pipefail"
           args: -d pixel_6
           filters: *filters
       - test-fastlane

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -283,6 +283,7 @@ workflows:
       - test_start_emulator_and_run_tests:
           name: test_start_emulator_and_run_tests-with-args
           tag: "default"
+          shell: bash -eox pipefail
           args: -d pixel_6
           filters: *filters
       - test-fastlane

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -130,6 +130,10 @@ jobs:
       tag:
         type: string
         description: "Android machine image tag to use."
+      args:
+        type: string
+        default: ""
+        description: Additional args to pass to avd creation
     executor:
       name: android/android_machine
       tag: << parameters.tag >>
@@ -148,6 +152,7 @@ jobs:
             - android/restore_build_cache
             - run: cd compose-samples/Jetchat && ./gradlew assembleDebugAndroidTest
           post_emulator_launch_assemble_command: ""
+          additional_avd_args: <<parameters.args>>
           run_tests_working_directory: ./compose-samples/Jetchat
           post_run_tests_steps:
             - android/save_build_cache
@@ -272,7 +277,13 @@ workflows:
       #     tag: "default"
       #     filters: *filters
       - test_start_emulator_and_run_tests:
+          name: test_start_emulator_and_run_tests
           tag: "default"
+          filters: *filters
+      - test_start_emulator_and_run_tests:
+          name: test_start_emulator_and_run_tests-with-args
+          tag: "default"
+          args: -d pixel_6
           filters: *filters
       - test-fastlane
       - orb-tools/pack:

--- a/src/executors/android_machine.yml
+++ b/src/executors/android_machine.yml
@@ -16,11 +16,7 @@ parameters:
     type: enum
     default: large
     enum: [medium, large, xlarge, 2xlarge]
-  shell:
-    type: string
-    default: "bash -eo pipefail"
 
 machine:
   image: android:<< parameters.tag >>
   resource_class: << parameters.resource_class >>
-  shell: <<parameters.shell>>

--- a/src/executors/android_machine.yml
+++ b/src/executors/android_machine.yml
@@ -16,7 +16,11 @@ parameters:
     type: enum
     default: large
     enum: [medium, large, xlarge, 2xlarge]
+  shell:
+    type: string
+    default: "bash -eo pipefail"
 
 machine:
   image: android:<< parameters.tag >>
   resource_class: << parameters.resource_class >>
+  shell: <<parameters.shell>>

--- a/src/scripts/create_avd.sh
+++ b/src/scripts/create_avd.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 PARAM_AVD_NAME="$(echo "$PARAM_AVD_NAME" | circleci env subst "$PARAM_AVD_NAME")"
 PARAM_SYSTEM_IMAGE="$(echo "$PARAM_SYSTEM_IMAGE" | circleci env subst "$PARAM_SYSTEM_IMAGE")"
-PARAM_ADDITIONAL_ARGS="$(echo "$PARAM_ADDITIONAL_ARGS" | circleci env subst "$PARAM_ADDITIONAL_ARGS")"
+PARAM_ADDITIONAL_ARGS="$(circleci env subst -- "$PARAM_ADDITIONAL_ARGS")"
 
 if [ "${PARAM_INSTALL}" == 1 ]; then
     sdkmanager "${PARAM_SYSTEM_IMAGE}"

--- a/src/scripts/create_avd.sh
+++ b/src/scripts/create_avd.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-PARAM_AVD_NAME="$(circleci env subst "$PARAM_AVD_NAME")"
-PARAM_SYSTEM_IMAGE="$(circleci env subst "$PARAM_SYSTEM_IMAGE")"
-PARAM_ADDITIONAL_ARGS="$(circleci env subst "$PARAM_ADDITIONAL_ARGS")"
+PARAM_AVD_NAME="$(echo "$PARAM_AVD_NAME" | circleci env subst "$PARAM_AVD_NAME")"
+PARAM_SYSTEM_IMAGE="$(echo "$PARAM_SYSTEM_IMAGE" | circleci env subst "$PARAM_SYSTEM_IMAGE")"
+PARAM_ADDITIONAL_ARGS="$(echo "$PARAM_ADDITIONAL_ARGS" | circleci env subst "$PARAM_ADDITIONAL_ARGS")"
 
 if [ "${PARAM_INSTALL}" == 1 ]; then
     sdkmanager "${PARAM_SYSTEM_IMAGE}"

--- a/src/scripts/run_tests.sh
+++ b/src/scripts/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-PARAM_PRE_TEST_COMMAND="$(circleci env subst "$PARAM_PRE_TEST_COMMAND")"
-PARAM_TEST_COMMAND="$(circleci env subst "$PARAM_TEST_COMMAND")"
+PARAM_PRE_TEST_COMMAND="$(echo "$PARAM_PRE_TEST_COMMAND" | circleci env subst "$PARAM_PRE_TEST_COMMAND")"
+PARAM_TEST_COMMAND="$(echo "$PARAM_TEST_COMMAND" | circleci env subst "$PARAM_TEST_COMMAND")"
 
 run_with_retry() {
   MAX_TRIES=${PARAM_MAX_TRIES}


### PR DESCRIPTION
Resolves #104 
The parameter PARAM_ADDITIONAL_ARGS is having an issue when replaced inside script, as the flags can be considered part of the circleci command instead of the full parameter. I'm updating the way the value is passed to avoid this problem.

A new test is added to validate this behavior.