### PR TITLE
Fixes bug with `run_tests` command interpretation

### DIFF
--- a/src/scripts/run_tests.sh
+++ b/src/scripts/run_tests.sh
@@ -7,8 +7,8 @@ run_with_retry() {
   n=1
   until [ $n -gt $MAX_TRIES ]; do
     echo "Starting test attempt $n"
-    ${PARAM_PRE_TEST_COMMAND}
-    ${PARAM_TEST_COMMAND} && break
+    eval "${PARAM_PRE_TEST_COMMAND}"
+    eval "${PARAM_TEST_COMMAND}" && break
     n=$((n + 1))
     sleep "${PARAM_RETRY_INTERVAL}"
   done


### PR DESCRIPTION
Adds `eval` to environment variables containing commands to ensure they are interpreted correctly.

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

Bug when interpreting commands set by user.

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

Adds `eval` to ensure all characters are interpreted as expected.

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
