### PR TITLE
Add Distribution Parameter to Change Java Version 

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -37,10 +37,10 @@ jobs:
           distribution: << parameters.java_distribution >>
       - run:
           command: |
-            DISTRIBUTION="$(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu|openjdk' | head -n1 || echo "unknown")"
+            DISTRIBUTION="$(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu' | head -n1 || echo "openjdk")"
             JAVA_VER="$( java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 )"
             JAVAC_VER="$( javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1 )"
-            if [ "$DISTRIBUTION" -ne <<parameters.java_distribution>> ]; then
+            if [ "$DISTRIBUTION" != <<parameters.java_distribution>> ]; then
               echo "Job failed because java distribution was not changed."
               echo "current java distribution:" $DISTRIBUTION
               exit 1

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -31,8 +31,14 @@ jobs:
           java_version: << parameters.java_version >>
       - run:
           command: |
+            DISTRIBUTION="$(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu|openjdk' | head -n1 || echo "unknown")"
             JAVA_VER="$( java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 )"
             JAVAC_VER="$( javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1 )"
+            if [ "$DISTRIBUTION" -ne <<parameters.java_distribution>> ]; then
+              echo "Job failed because java distribution was not changed."
+              echo "current java distribution:" $DISTRIBUTION
+              exit 1
+            fi
             if [ "$JAVA_VER" -ne <<parameters.java_version>> ]; then
               echo "Job failed because java version was not changed."
               echo "current java version:" $JAVA_VER
@@ -41,31 +47,6 @@ jobs:
             if [ "$JAVAC_VER" -ne <<parameters.java_version>> ]; then
               echo "Job failed because javac version was not changed."
               echo "current javac version:" $JAVAC_VER
-              exit 1
-            fi
-          name: check for correctness
-  test_java_distribution:
-    parameters:
-      executor:
-        type: executor
-        description: |
-          Which Android image/executor to use. Choose between 'android_docker'
-          and 'android_machine'.
-      java_distribution:
-        type: integer
-        description: |
-          Distribution to use in the change_java_version job
-    executor: <<parameters.executor>>
-    steps:
-      - checkout
-      - android/change_java_version:
-          distribution: << parameters.java_distribution >>
-      - run:
-          command: |
-            DISTRIBUTION="$(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu|openjdk' | head -n1 || echo "unknown")"
-            if [ "$DISTRIBUTION" -ne <<parameters.java_distribution>> ]; then
-              echo "Job failed because java distribution was not changed."
-              echo "current java distribution:" $DISTRIBUTION
               exit 1
             fi
           name: check for correctness
@@ -245,20 +226,12 @@ workflows:
                 - 17
                 - 18
                 - 21
-          filters: *filters
-      - test_java_distribution:
-          name: "Test Java distribution change"
-          executor:
-            name: android/android_docker
-            tag: "2023.05.1"
-          matrix:
-            parameters:
               java_distribution:
                 - openjdk
                 - temurin
                 - corretto
                 - zulu
-          filters: *filters   
+          filters: *filters
       - test-ndk-install:
           name: "Test NDK Install on Android Docker"
           matrix:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -29,6 +29,7 @@ jobs:
       - checkout
       - android/change_java_version:
           java_version: << parameters.java_version >>
+          distribution: << parameters.java_distribution >>
       - run:
           command: |
             DISTRIBUTION="$(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu|openjdk' | head -n1 || echo "unknown")"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -24,6 +24,11 @@ jobs:
         type: integer
         description: |
           Version to use in the change_java_version job
+      java_distribution:
+        type: enum
+        enum: [openjdk, corretto, temurin, zulu]
+        description: |
+          Distribution to use in the change_java_version job
     executor: <<parameters.executor>>
     steps:
       - checkout

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -44,6 +44,31 @@ jobs:
               exit 1
             fi
           name: check for correctness
+  test_java_distribution:
+    parameters:
+      executor:
+        type: executor
+        description: |
+          Which Android image/executor to use. Choose between 'android_docker'
+          and 'android_machine'.
+      java_distribution:
+        type: integer
+        description: |
+          Distribution to use in the change_java_version job
+    executor: <<parameters.executor>>
+    steps:
+      - checkout
+      - android/change_java_version:
+          distribution: << parameters.java_distribution >>
+      - run:
+          command: |
+            DISTRIBUTION="$(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu|openjdk' | head -n1 || echo "unknown")"
+            if [ "$DISTRIBUTION" -ne <<parameters.java_distribution>> ]; then
+              echo "Job failed because java distribution was not changed."
+              echo "current java distribution:" $DISTRIBUTION
+              exit 1
+            fi
+          name: check for correctness
   test-ndk-install:
     parameters:
       executor:
@@ -221,6 +246,19 @@ workflows:
                 - 18
                 - 21
           filters: *filters
+      - test_java_distribution:
+          name: "Test Java distribution change"
+          executor:
+            name: android/android_docker
+            tag: "2023.05.1"
+          matrix:
+            parameters:
+              java_distribution:
+                - openjdk
+                - temurin
+                - corretto
+                - zulu
+          filters: *filters   
       - test-ndk-install:
           name: "Test NDK Install on Android Docker"
           matrix:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -220,7 +220,6 @@ workflows:
       - test-malloc:
           name: "Test Changing Malloc Implementations"
       - test_java_version:
-          name: "Test OpenJDK version change"
           executor:
             name: android/android_docker
             tag: "2023.05.1"

--- a/src/commands/change_java_version.yml
+++ b/src/commands/change_java_version.yml
@@ -6,9 +6,14 @@ parameters:
     default: 8
     description: |
       The version of OpenJDK to change to
+  distribution:
+    type: enum
+    default: openjdk
+    enum: [openjdk, corretto, temurin, zulu]
 steps:
   - run:
       environment:
         PARAM_JAVA_VER: << parameters.java_version >>
-      name: Change OpenJDK version to << parameters.java_version >>
+        PARAM_DISTRIBUTION: << parameters.distribution >>
+      name: Change << parameters.distribution >> version to << parameters.java_version >>
       command: <<include(scripts/change_java_version.sh)>>

--- a/src/commands/change_java_version.yml
+++ b/src/commands/change_java_version.yml
@@ -5,11 +5,13 @@ parameters:
     type: integer
     default: 8
     description: |
-      The version of OpenJDK to change to
+      The version of JDK to change to
   distribution:
     type: enum
     default: openjdk
     enum: [openjdk, corretto, temurin, zulu]
+    description: |
+      The distribution of JDK to change to
 steps:
   - run:
       environment:

--- a/src/scripts/change_java_version.sh
+++ b/src/scripts/change_java_version.sh
@@ -2,6 +2,7 @@
 CURRENT_DISTRIBUTION="$(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu|openjdk' | head -n1 || echo "unknown")"
 CURRENT_JAVA_VER="$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)"
 CURRENT_JAVAC_VER="$(javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1)"
+echo "Current Java Distribution: $CURRENT_DISTRIBUTION"
 echo "Current Java Version: $CURRENT_JAVA_VER"
 echo "Current Java Compiler Version : $CURRENT_JAVAC_VER"
 if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ] || [ "$CURRENT_DISTRIBUTION" != "${PARAM_DISTRIBUTION}" ]; then
@@ -76,7 +77,9 @@ if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ] || [ "$CURRENT_DISTRIBUTION" 
   fi
   echo "export PATH=\$JAVA_HOME/bin:\$PATH" >> "$BASH_ENV"
 fi
+NEW_DISTRIBUTION="$(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu|openjdk' | head -n1 || echo "unknown")"
 NEW_JAVA_VER="$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)"
 NEW_JAVAC_VER="$(javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1)"
+echo "New Java Distribution: $NEW_DISTRIBUTION"
 echo "New Java Version : $NEW_JAVA_VER"
 echo "New Java Compiler Version : $NEW_JAVAC_VER"

--- a/src/scripts/change_java_version.sh
+++ b/src/scripts/change_java_version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-CURRENT_DISTRIBUTON="$(echo $(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu|openjdk' | head -n1 || echo "unknown"))"
+CURRENT_DISTRIBUTION="$(echo $(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu|openjdk' | head -n1 || echo "unknown"))"
 CURRENT_JAVA_VER="$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)"
 CURRENT_JAVAC_VER="$(javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1)"
 echo "Current Java Version: $CURRENT_JAVA_VER"
@@ -31,7 +31,7 @@ if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ] && [ "$CURRENT_DISTRIBUTION" 
         sudo apt install java-"${PARAM_JAVA_VER}"-amazon-corretto-jdk
         sudo update-alternatives --set javac /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-amazon-corretto/bin/javac
         sudo update-alternatives --set java /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-amazon-corretto/bin/java
-        echo "export JAVA_HOME=/usr/lib/jvm/java-"${PARAM_JAVA_VER}"-amazon-corretto" >> "$BASH_ENV"
+        echo "export JAVA_HOME=/usr/lib/jvm/java-${PARAM_JAVA_VER}-amazon-corretto" >> "$BASH_ENV"
         ;;
       "temurin")
         sudo apt update
@@ -42,7 +42,7 @@ if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ] && [ "$CURRENT_DISTRIBUTION" 
         sudo apt install temurin-"${PARAM_JAVA_VER}"-jdk
         sudo update-alternatives --set javac /usr/lib/jvm/temurin-"${PARAM_JAVA_VER}"-jdk-amd64/bin/javac
         sudo update-alternatives --set java /usr/lib/jvm/temurin-"${PARAM_JAVA_VER}"-jdk-amd64/bin/java
-        echo "export JAVA_HOME=/usr/lib/jvm/temurin-"${PARAM_JAVA_VER}"-jdk-amd64" >> "$BASH_ENV"
+        echo "export JAVA_HOME=/usr/lib/jvm/temurin-${PARAM_JAVA_VER}-jdk-amd64" >> "$BASH_ENV"
         ;;
       "zulu")
         sudo apt update
@@ -53,7 +53,7 @@ if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ] && [ "$CURRENT_DISTRIBUTION" 
         sudo apt install zulu"${PARAM_JAVA_VER}"-jdk
         sudo update-alternatives --set javac /usr/lib/jvm/zulu-"${PARAM_JAVA_VER}"-amd64/bin/javac
         sudo update-alternatives --set java /usr/lib/jvm/zulu-"${PARAM_JAVA_VER}"-amd64/bin/java
-        echo "export JAVA_HOME=/usr/lib/jvm/zulu-"${PARAM_JAVA_VER}"-amd64" >> "$BASH_ENV"
+        echo "export JAVA_HOME=/usr/lib/jvm/zulu-${PARAM_JAVA_VER}-amd64" >> "$BASH_ENV"
         ;;
       *)
         echo "Unknown distribution: ${PARAM_DISTRIBUTION}"

--- a/src/scripts/change_java_version.sh
+++ b/src/scripts/change_java_version.sh
@@ -28,10 +28,21 @@ if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ] || [ "$CURRENT_DISTRIBUTION" 
         wget -O- https://apt.corretto.aws/corretto.key | sudo apt-key add -
         sudo add-apt-repository -y 'deb https://apt.corretto.aws stable main'
         sudo apt update
-        sudo apt install java-"${PARAM_JAVA_VER}"-amazon-corretto-jdk
-        sudo update-alternatives --set javac /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-amazon-corretto/bin/javac
-        sudo update-alternatives --set java /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-amazon-corretto/bin/java
-        echo "export JAVA_HOME=/usr/lib/jvm/java-${PARAM_JAVA_VER}-amazon-corretto" >> "$BASH_ENV"
+        if [ "${PARAM_JAVA_VER}" -eq 8 ]; then
+          sudo apt install -y java-1.8.0-amazon-corretto-jdk
+          sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/java 1
+          sudo update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/javac 1
+          sudo update-alternatives --set javac /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/javac
+          sudo update-alternatives --set java /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/java
+          echo "export JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto" >> "$BASH_ENV"
+        else
+          sudo apt install -y java-"${PARAM_JAVA_VER}"-amazon-corretto-jdk
+          sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-amazon-corretto/bin/java 1
+          sudo update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-amazon-corretto/bin/javac 1
+          sudo update-alternatives --set javac /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-amazon-corretto/bin/javac
+          sudo update-alternatives --set java /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-amazon-corretto/bin/java
+          echo "export JAVA_HOME=/usr/lib/jvm/java-${PARAM_JAVA_VER}-amazon-corretto" >> "$BASH_ENV"
+        fi
         ;;
       "temurin")
         sudo apt update
@@ -51,9 +62,11 @@ if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ] || [ "$CURRENT_DISTRIBUTION" 
         sudo apt-add-repository -y 'deb http://repos.azul.com/zulu/deb stable main'
         sudo apt update
         sudo apt install zulu"${PARAM_JAVA_VER}"-jdk
-        sudo update-alternatives --set javac /usr/lib/jvm/zulu-"${PARAM_JAVA_VER}"-amd64/bin/javac
-        sudo update-alternatives --set java /usr/lib/jvm/zulu-"${PARAM_JAVA_VER}"-amd64/bin/java
-        echo "export JAVA_HOME=/usr/lib/jvm/zulu-${PARAM_JAVA_VER}-amd64" >> "$BASH_ENV"
+        sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/zulu"${PARAM_JAVA_VER}"-ca-amd64/bin/java 1
+        sudo update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/zulu"${PARAM_JAVA_VER}"-ca-amd64/bin/javac 1
+        sudo update-alternatives --set javac /usr/lib/jvm/zulu-"${PARAM_JAVA_VER}"-ca-amd64/bin/javac
+        sudo update-alternatives --set java /usr/lib/jvm/zulu-"${PARAM_JAVA_VER}"-ca-amd64/bin/java
+        echo "export JAVA_HOME=/usr/lib/jvm/zulu-${PARAM_JAVA_VER}-ca-amd64" >> "$BASH_ENV"
         ;;
       *)
         echo "Unknown distribution: ${PARAM_DISTRIBUTION}"

--- a/src/scripts/change_java_version.sh
+++ b/src/scripts/change_java_version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-CURRENT_DISTRIBUTION="$(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu|openjdk' | head -n1 || echo "unknown")"
+CURRENT_DISTRIBUTION="$(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu' | head -n1 || echo "openjdk")"
 CURRENT_JAVA_VER="$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)"
 CURRENT_JAVAC_VER="$(javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1)"
 echo "Current Java Distribution: $CURRENT_DISTRIBUTION"
@@ -77,7 +77,7 @@ if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ] || [ "$CURRENT_DISTRIBUTION" 
   fi
   echo "export PATH=\$JAVA_HOME/bin:\$PATH" >> "$BASH_ENV"
 fi
-NEW_DISTRIBUTION="$(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu|openjdk' | head -n1 || echo "unknown")"
+NEW_DISTRIBUTION="$(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu' | head -n1 || echo "openjdk")"
 NEW_JAVA_VER="$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)"
 NEW_JAVAC_VER="$(javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1)"
 echo "New Java Distribution: $NEW_DISTRIBUTION"

--- a/src/scripts/change_java_version.sh
+++ b/src/scripts/change_java_version.sh
@@ -65,8 +65,8 @@ if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ] || [ "$CURRENT_DISTRIBUTION" 
         sudo apt install zulu"${PARAM_JAVA_VER}"-jdk
         sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/zulu"${PARAM_JAVA_VER}"-ca-amd64/bin/java 1
         sudo update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/zulu"${PARAM_JAVA_VER}"-ca-amd64/bin/javac 1
-        sudo update-alternatives --set javac /usr/lib/jvm/zulu-"${PARAM_JAVA_VER}"-ca-amd64/bin/javac
-        sudo update-alternatives --set java /usr/lib/jvm/zulu-"${PARAM_JAVA_VER}"-ca-amd64/bin/java
+        sudo update-alternatives --set javac /usr/lib/jvm/zulu"${PARAM_JAVA_VER}"-ca-amd64/bin/javac
+        sudo update-alternatives --set java /usr/lib/jvm/zulu"${PARAM_JAVA_VER}"-ca-amd64/bin/java
         echo "export JAVA_HOME=/usr/lib/jvm/zulu-${PARAM_JAVA_VER}-ca-amd64" >> "$BASH_ENV"
         ;;
       *)

--- a/src/scripts/change_java_version.sh
+++ b/src/scripts/change_java_version.sh
@@ -4,7 +4,7 @@ CURRENT_JAVA_VER="$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s/
 CURRENT_JAVAC_VER="$(javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1)"
 echo "Current Java Version: $CURRENT_JAVA_VER"
 echo "Current Java Compiler Version : $CURRENT_JAVAC_VER"
-if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ] && [ "$CURRENT_DISTRIBUTION" != "${PARAM_DISTRIBUTION}" ]; then
+if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ] || [ "$CURRENT_DISTRIBUTION" != "${PARAM_DISTRIBUTION}" ]; then
   if [ "${PARAM_DISTRIBUTION}" = "openjdk" ]; then
     if [ "${PARAM_JAVA_VER}" -eq 8 ] || [ "${PARAM_JAVA_VER}" -eq 17 ]; then
       if [ "${PARAM_JAVA_VER}" -eq 8 ]; then

--- a/src/scripts/change_java_version.sh
+++ b/src/scripts/change_java_version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-CURRENT_DISTRIBUTION="$(echo $(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu|openjdk' | head -n1 || echo "unknown"))"
+CURRENT_DISTRIBUTION="$(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu|openjdk' | head -n1 || echo "unknown")"
 CURRENT_JAVA_VER="$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)"
 CURRENT_JAVAC_VER="$(javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1)"
 echo "Current Java Version: $CURRENT_JAVA_VER"

--- a/src/scripts/change_java_version.sh
+++ b/src/scripts/change_java_version.sh
@@ -1,23 +1,66 @@
 #!/bin/bash
+CURRENT_DISTRIBUTON="$(echo $(java -version 2>&1 | tr '[:upper:]' '[:lower:]' | grep -Eo 'corretto|temurin|zulu|openjdk' | head -n1 || echo "unknown"))"
 CURRENT_JAVA_VER="$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)"
 CURRENT_JAVAC_VER="$(javac -version 2>&1 | head -1 | cut -f 2- -d ' ' | sed '/^1\./s///' | cut -d'.' -f1)"
 echo "Current Java Version: $CURRENT_JAVA_VER"
 echo "Current Java Compiler Version : $CURRENT_JAVAC_VER"
-if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ]; then
-  if [ "${PARAM_JAVA_VER}" -eq 8 ] || [ "${PARAM_JAVA_VER}" -eq 17 ]; then
-    if [ "${PARAM_JAVA_VER}" -eq 8 ]; then
-      sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ] && [ "$CURRENT_DISTRIBUTION" != "${PARAM_DISTRIBUTION}" ]; then
+  if [ "${PARAM_DISTRIBUTION}" = "openjdk" ]; then
+    if [ "${PARAM_JAVA_VER}" -eq 8 ] || [ "${PARAM_JAVA_VER}" -eq 17 ]; then
+      if [ "${PARAM_JAVA_VER}" -eq 8 ]; then
+        sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+      else
+        sudo update-alternatives --set java /usr/lib/jvm/java-17-openjdk-amd64/bin/java
+      fi
+      sudo update-alternatives --set javac /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-openjdk-amd64/bin/javac
     else
-      sudo update-alternatives --set java /usr/lib/jvm/java-17-openjdk-amd64/bin/java
+      sudo apt-get update
+      sudo apt install openjdk-"${PARAM_JAVA_VER}"-jdk
+      sudo update-alternatives --set javac /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-openjdk-amd64/bin/javac
+      sudo update-alternatives --set java /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-openjdk-amd64/bin/java
     fi
-    sudo update-alternatives --set javac /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-openjdk-amd64/bin/javac
-  else
-    sudo apt-get update
-    sudo apt install openjdk-"${PARAM_JAVA_VER}"-jdk
-    sudo update-alternatives --set javac /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-openjdk-amd64/bin/javac
-    sudo update-alternatives --set java /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-openjdk-amd64/bin/java
+    echo "export JAVA_HOME=/usr/lib/jvm/java-${PARAM_JAVA_VER}-openjdk-amd64" >> "$BASH_ENV"
+  else 
+    case "${PARAM_DISTRIBUTION}" in
+      "corretto")
+        sudo apt update
+        sudo apt install wget gnupg
+        wget -O- https://apt.corretto.aws/corretto.key | sudo apt-key add -
+        sudo add-apt-repository 'deb https://apt.corretto.aws stable main'
+        sudo apt update
+        sudo apt install java-"${PARAM_JAVA_VER}"-amazon-corretto-jdk
+        sudo update-alternatives --set javac /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-amazon-corretto/bin/javac
+        sudo update-alternatives --set java /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-amazon-corretto/bin/java
+        echo "export JAVA_HOME=/usr/lib/jvm/java-"${PARAM_JAVA_VER}"-amazon-corretto" >> "$BASH_ENV"
+        ;;
+      "temurin")
+        sudo apt update
+        sudo apt install wget apt-transport-https gpg
+        wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo gpg --dearmor -o /usr/share/keyrings/adoptium.gpg
+        echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
+        sudo apt update
+        sudo apt install temurin-"${PARAM_JAVA_VER}"-jdk
+        sudo update-alternatives --set javac /usr/lib/jvm/temurin-"${PARAM_JAVA_VER}"-jdk-amd64/bin/javac
+        sudo update-alternatives --set java /usr/lib/jvm/temurin-"${PARAM_JAVA_VER}"-jdk-amd64/bin/java
+        echo "export JAVA_HOME=/usr/lib/jvm/temurin-"${PARAM_JAVA_VER}"-jdk-amd64" >> "$BASH_ENV"
+        ;;
+      "zulu")
+        sudo apt update
+        sudo apt install gnupg software-properties-common
+        wget -qO - https://repos.azul.com/azul-repo.key | sudo apt-key add -
+        sudo apt-add-repository 'deb http://repos.azul.com/zulu/deb stable main'
+        sudo apt update
+        sudo apt install zulu"${PARAM_JAVA_VER}"-jdk
+        sudo update-alternatives --set javac /usr/lib/jvm/zulu-"${PARAM_JAVA_VER}"-amd64/bin/javac
+        sudo update-alternatives --set java /usr/lib/jvm/zulu-"${PARAM_JAVA_VER}"-amd64/bin/java
+        echo "export JAVA_HOME=/usr/lib/jvm/zulu-"${PARAM_JAVA_VER}"-amd64" >> "$BASH_ENV"
+        ;;
+      *)
+        echo "Unknown distribution: ${PARAM_DISTRIBUTION}"
+        return 1
+        ;;
+    esac
   fi
-  echo "export JAVA_HOME=/usr/lib/jvm/java-${PARAM_JAVA_VER}-openjdk-amd64" >> "$BASH_ENV"
   echo "export PATH=\$JAVA_HOME/bin:\$PATH" >> "$BASH_ENV"
 fi
 NEW_JAVA_VER="$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)"

--- a/src/scripts/change_java_version.sh
+++ b/src/scripts/change_java_version.sh
@@ -26,7 +26,7 @@ if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ] || [ "$CURRENT_DISTRIBUTION" 
         sudo apt update
         sudo apt install wget gnupg
         wget -O- https://apt.corretto.aws/corretto.key | sudo apt-key add -
-        sudo add-apt-repository 'deb https://apt.corretto.aws stable main'
+        sudo add-apt-repository -y 'deb https://apt.corretto.aws stable main'
         sudo apt update
         sudo apt install java-"${PARAM_JAVA_VER}"-amazon-corretto-jdk
         sudo update-alternatives --set javac /usr/lib/jvm/java-"${PARAM_JAVA_VER}"-amazon-corretto/bin/javac
@@ -48,7 +48,7 @@ if [ "$CURRENT_JAVA_VER" -ne "${PARAM_JAVA_VER}" ] || [ "$CURRENT_DISTRIBUTION" 
         sudo apt update
         sudo apt install gnupg software-properties-common
         wget -qO - https://repos.azul.com/azul-repo.key | sudo apt-key add -
-        sudo apt-add-repository 'deb http://repos.azul.com/zulu/deb stable main'
+        sudo apt-add-repository -y 'deb http://repos.azul.com/zulu/deb stable main'
         sudo apt update
         sudo apt install zulu"${PARAM_JAVA_VER}"-jdk
         sudo update-alternatives --set javac /usr/lib/jvm/zulu-"${PARAM_JAVA_VER}"-amd64/bin/javac


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Currently the `change_java_version` command is set to OpenJDK. Not all users of the orb will want/need OpenJDK which leads to custom code added to workflows. By adding an optional parameter we can give users the ability to use this command for a set list of distributions.

### Description

add `distribution` parameter to command `change_java_version`
